### PR TITLE
Migrate to using a GitHub workflow for releases and PR validation

### DIFF
--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -1,0 +1,117 @@
+name: Build release bundle
+
+on:
+  release:
+    types: [published]
+  pull_request:
+
+jobs:
+  build-bundle:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set version from release tag
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Using version: ${VERSION}"
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
+          sed -i "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" frontend/package.json
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Add uv to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install backend dependencies
+        run: uv sync
+
+      - name: Backend lint (Ruff)
+        run: |
+          uv run ruff check app/ tests/ --fix
+          uv run ruff format app/ tests/
+          uv run ruff check app/ tests/
+          uv run ruff format --check app/ tests/
+
+      - name: Backend type check (Pyright)
+        run: uv run pyright app/
+
+      - name: Backend tests (pytest)
+        run: PYTHONPATH=. uv run pytest tests/ -v
+
+      - name: Install frontend dependencies
+        run: |
+          cd frontend
+          npm ci
+
+      - name: Frontend lint (ESLint)
+        run: |
+          cd frontend
+          npm run lint
+
+      - name: Frontend format check (Prettier)
+        run: |
+          cd frontend
+          npm run format:check
+
+      - name: Frontend tests
+        run: |
+          cd frontend
+          npm run test:run
+
+      - name: Frontend build
+        run: |
+          cd frontend
+          npm run build
+
+      - name: Build bundle
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          bash scripts/build_release_bundle.sh
+
+      - name: Upload bundle to release
+        if: ${{ github.event_name == 'release' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist-bundle/remoteterm-linux-x64.tar.gz
+
+      - name: Set up Docker Buildx
+        if: ${{ github.event_name == 'release' }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: ${{ github.event_name == 'release' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        if: ${{ github.event_name == 'release' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ env.VERSION }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ wheels/
 .venv
 frontend/node_modules/
 frontend/test-results/
+frontend/dist/
 
 # reference librarys
 references/

--- a/README.md
+++ b/README.md
@@ -57,13 +57,17 @@ usbipd bind --busid 3-8
 
 **This approach is recommended over Docker due to intermittent serial communications issues I've seen on \*nix systems.**
 
-The frontend is pre-built -- just run the backend:
+Build the frontend once, then run the backend:
 
 ```bash
 git clone https://github.com/jkingsman/Remote-Terminal-for-MeshCore.git
 cd Remote-Terminal-for-MeshCore
 
 uv sync
+cd frontend
+npm install
+npm run build
+cd ..
 uv run uvicorn app.main:app --host 0.0.0.0 --port 8000
 ```
 
@@ -87,6 +91,18 @@ docker run -d \
   -p 8000:8000 \
   jkingsman/remote-terminal-for-meshcore:latest
 ```
+
+## Release Bundle (No npm needed)
+
+Each GitHub Release includes a Linux bundle with the backend, a prebuilt frontend, and a local Python virtual environment.
+
+```bash
+tar -xzf remoteterm-linux-x64.tar.gz
+cd remoteterm
+./run.sh
+```
+
+The server runs at http://localhost:8000
 
 ## Development
 
@@ -193,7 +209,7 @@ cd /opt/remoteterm
 sudo -u remoteterm uv venv
 sudo -u remoteterm uv sync
 
-# Build frontend (optional -- already built in repo and served by backend)
+# Build frontend
 cd /opt/remoteterm/frontend
 sudo -u remoteterm npm install
 sudo -u remoteterm npm run build

--- a/scripts/build_release_bundle.sh
+++ b/scripts/build_release_bundle.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${ROOT_DIR}/dist-bundle"
+BUNDLE_DIR="${OUT_DIR}/remoteterm"
+
+rm -rf "${OUT_DIR}"
+mkdir -p "${BUNDLE_DIR}"
+
+# Copy backend source
+cp -R "${ROOT_DIR}/app" "${BUNDLE_DIR}/app"
+cp "${ROOT_DIR}/pyproject.toml" "${BUNDLE_DIR}/pyproject.toml"
+cp "${ROOT_DIR}/uv.lock" "${BUNDLE_DIR}/uv.lock"
+cp "${ROOT_DIR}/README.md" "${BUNDLE_DIR}/README.md"
+
+# Build frontend
+pushd "${ROOT_DIR}/frontend" >/dev/null
+npm ci
+npm run build
+popd >/dev/null
+
+# Copy built frontend assets
+mkdir -p "${BUNDLE_DIR}/frontend"
+cp -R "${ROOT_DIR}/frontend/dist" "${BUNDLE_DIR}/frontend/dist"
+
+# Create venv with dependencies (no dev)
+pushd "${BUNDLE_DIR}" >/dev/null
+uv venv .venv
+. .venv/bin/activate
+uv sync --frozen --no-dev
+
+deactivate
+popd >/dev/null
+
+# Create run script
+cat > "${BUNDLE_DIR}/run.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export PYTHONPATH="${ROOT_DIR}"
+
+source "${ROOT_DIR}/.venv/bin/activate"
+
+exec uv run uvicorn app.main:app --host 0.0.0.0 --port 8000
+EOF
+
+chmod +x "${BUNDLE_DIR}/run.sh"
+
+# Package
+pushd "${OUT_DIR}" >/dev/null
+tar -czf remoteterm-linux-x64.tar.gz remoteterm
+popd >/dev/null
+
+echo "Bundle created: ${OUT_DIR}/remoteterm-linux-x64.tar.gz"


### PR DESCRIPTION
This is a draft PR  - but to make it easier to accept PRs and cut releases, this adds GitHub Workflow steps that run all the same steps you have in the publish.sh script.

This removes the need to have the generated/built files checked into the repo (usually not recommended) and makes it easy to cut a new release through the GitHub release mechanism. You would need to configure a repo secret with a GitHub Token to allow it to publish the docker images to GHCR, or you could replace that step with a similar action for pushing to Docker Hub although then you need a username and API token.

The goal is to make the project easier to maintain and cut releases whenever you are ready to do so.

You could also drop the release parts of this workflow and just have it run validation and build steps on a PR to at least get the PR safety aspects up and going.