### PR TITLE
Add resend flow for low-repeat channel messages

### DIFF
--- a/app/repository.py
+++ b/app/repository.py
@@ -496,6 +496,38 @@ class MessageRepository:
         ]
 
     @staticmethod
+    async def get_by_id(message_id: int) -> Message | None:
+        """Get a single message by ID."""
+        cursor = await db.conn.execute("SELECT * FROM messages WHERE id = ?", (message_id,))
+        row = await cursor.fetchone()
+        if not row:
+            return None
+
+        return Message(
+            id=row["id"],
+            type=row["type"],
+            conversation_key=row["conversation_key"],
+            text=row["text"],
+            sender_timestamp=row["sender_timestamp"],
+            received_at=row["received_at"],
+            paths=MessageRepository._parse_paths(row["paths"]),
+            txt_type=row["txt_type"],
+            signature=row["signature"],
+            outgoing=bool(row["outgoing"]),
+            acked=row["acked"],
+        )
+
+    @staticmethod
+    async def update_sender_timestamp(message_id: int, sender_timestamp: int) -> bool:
+        """Update sender_timestamp for an existing message."""
+        cursor = await db.conn.execute(
+            "UPDATE messages SET sender_timestamp = ? WHERE id = ?",
+            (sender_timestamp, message_id),
+        )
+        await db.conn.commit()
+        return cursor.rowcount > 0
+
+    @staticmethod
     async def increment_ack_count(message_id: int) -> int:
         """Increment ack count and return the new value."""
         await db.conn.execute("UPDATE messages SET acked = acked + 1 WHERE id = ?", (message_id,))

--- a/app/routers/messages.py
+++ b/app/routers/messages.py
@@ -161,6 +161,15 @@ TEMP_RADIO_SLOT = 0
 EXPERIMENTAL_CHANNEL_DOUBLE_SEND_DELAY_SECONDS = 3
 
 
+def _strip_channel_sender_prefix(stored_text: str, radio_name: str) -> str:
+    """Best-effort conversion from stored channel text ('name: msg') to payload text."""
+    if radio_name:
+        prefix = f"{radio_name}: "
+        if stored_text.startswith(prefix):
+            return stored_text[len(prefix) :]
+    return stored_text
+
+
 @router.post("/channel", response_model=Message)
 async def send_channel_message(request: SendChannelMessageRequest) -> Message:
     """Send a message to a channel."""
@@ -306,3 +315,132 @@ async def send_channel_message(request: SendChannelMessageRequest) -> Message:
     )
 
     return message
+
+
+@router.post("/{message_id}/resend")
+async def resend_message(message_id: int) -> dict:
+    """Re-send an existing outgoing message without creating a duplicate DB row."""
+    mc = require_connected()
+
+    from app.repository import AppSettingsRepository, ChannelRepository, ContactRepository
+
+    message = await MessageRepository.get_by_id(message_id)
+    if not message:
+        raise HTTPException(status_code=404, detail=f"Message {message_id} not found")
+    if not message.outgoing:
+        raise HTTPException(status_code=400, detail="Only outgoing messages can be re-sent")
+
+    original_timestamp = int(message.sender_timestamp or message.received_at)
+    resend_timestamp = int(time.time())
+    if resend_timestamp <= original_timestamp:
+        resend_timestamp = original_timestamp + 1
+
+    if message.type == "PRIV":
+        try:
+            db_contact = await ContactRepository.get_by_key_or_prefix(message.conversation_key)
+        except AmbiguousPublicKeyPrefixError as err:
+            sample = ", ".join(key[:12] for key in err.matches[:2])
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Ambiguous destination key prefix '{err.prefix}'. "
+                    f"Use a full 64-character public key. Matching contacts: {sample}"
+                ),
+            ) from err
+        if not db_contact:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Contact not found in database: {message.conversation_key}",
+            )
+
+        contact_data = db_contact.to_radio_dict()
+        # Retimestamp first so any immediate echo/duplicate maps to this same message row.
+        await MessageRepository.update_sender_timestamp(message_id, resend_timestamp)
+
+        async with radio_manager.radio_operation("resend_direct_message"):
+            add_result = await mc.commands.add_contact(contact_data)
+            if add_result.type == EventType.ERROR:
+                logger.warning("Failed to add contact to radio: %s", add_result.payload)
+
+            contact = mc.get_contact_by_key_prefix(db_contact.public_key[:12]) or contact_data
+            result = await mc.commands.send_msg(
+                dst=contact,
+                msg=message.text,
+                timestamp=resend_timestamp,
+            )
+
+        if result.type == EventType.ERROR:
+            await MessageRepository.update_sender_timestamp(message_id, original_timestamp)
+            raise HTTPException(status_code=500, detail=f"Failed to send message: {result.payload}")
+
+        await ContactRepository.update_last_contacted(db_contact.public_key.lower(), int(time.time()))
+
+        expected_ack = result.payload.get("expected_ack")
+        suggested_timeout: int = result.payload.get("suggested_timeout", 10000)
+        if expected_ack:
+            ack_code = expected_ack.hex() if isinstance(expected_ack, bytes) else expected_ack
+            track_pending_ack(ack_code, message_id, suggested_timeout)
+            logger.debug("Tracking ACK %s for re-sent message %d", ack_code, message_id)
+
+        return {"status": "ok", "message_id": message_id}
+
+    if message.type == "CHAN":
+        db_channel = await ChannelRepository.get_by_key(message.conversation_key)
+        if not db_channel:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Channel {message.conversation_key} not found in database",
+            )
+        app_settings = await AppSettingsRepository.get()
+
+        try:
+            key_bytes = bytes.fromhex(message.conversation_key)
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid channel key format: {message.conversation_key}",
+            ) from None
+
+        timestamp_bytes = resend_timestamp.to_bytes(4, "little")
+        radio_name = mc.self_info.get("name", "") if mc.self_info else ""
+        payload_text = _strip_channel_sender_prefix(message.text, radio_name)
+
+        await MessageRepository.update_sender_timestamp(message_id, resend_timestamp)
+
+        async with radio_manager.radio_operation("resend_channel_message"):
+            set_result = await mc.commands.set_channel(
+                channel_idx=TEMP_RADIO_SLOT,
+                channel_name=db_channel.name,
+                channel_secret=key_bytes,
+            )
+            if set_result.type == EventType.ERROR:
+                raise HTTPException(
+                    status_code=500,
+                    detail="Failed to configure channel on radio before sending message",
+                )
+
+            result = await mc.commands.send_chan_msg(
+                chan=TEMP_RADIO_SLOT,
+                msg=payload_text,
+                timestamp=timestamp_bytes,
+            )
+            if result.type == EventType.ERROR:
+                await MessageRepository.update_sender_timestamp(message_id, original_timestamp)
+                raise HTTPException(status_code=500, detail=f"Failed to send message: {result.payload}")
+
+            if app_settings.experimental_channel_double_send:
+                await asyncio.sleep(EXPERIMENTAL_CHANNEL_DOUBLE_SEND_DELAY_SECONDS)
+                duplicate_result = await mc.commands.send_chan_msg(
+                    chan=TEMP_RADIO_SLOT,
+                    msg=payload_text,
+                    timestamp=timestamp_bytes,
+                )
+                if duplicate_result.type == EventType.ERROR:
+                    logger.warning(
+                        "Experimental duplicate channel resend failed: %s",
+                        duplicate_result.payload,
+                    )
+
+        return {"status": "ok", "message_id": message_id}
+
+    raise HTTPException(status_code=400, detail=f"Unsupported message type: {message.type}")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -592,6 +592,18 @@ export function App() {
     [activeConversation, addMessageIfNew]
   );
 
+  const handleResendMessage = useCallback(async (messageId: number) => {
+    try {
+      await api.resendMessage(messageId);
+      toast.success('Message sent again');
+    } catch (err) {
+      console.error('Failed to resend message:', err);
+      toast.error('Failed to resend message', {
+        description: err instanceof Error ? err.message : 'Check radio connection',
+      });
+    }
+  }, []);
+
   // Config save handler
   const handleSaveConfig = useCallback(
     async (update: RadioConfigUpdate) => {
@@ -1184,6 +1196,7 @@ export function App() {
                     onLoadOlder={fetchOlderMessages}
                     radioName={config?.name}
                     config={config}
+                    onResendMessage={handleResendMessage}
                   />
                   <MessageInput
                     ref={messageInputRef}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -166,6 +166,10 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ channel_key: channelKey, text }),
     }),
+  resendMessage: (messageId: number) =>
+    fetchJson<{ status: string; message_id: number }>(`/messages/${messageId}/resend`, {
+      method: 'POST',
+    }),
 
   // Packets
   getUndecryptedPacketCount: () => fetchJson<{ count: number }>('/packets/undecrypted/count'),

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -25,6 +25,7 @@ interface MessageListProps {
   onLoadOlder?: () => void;
   radioName?: string;
   config?: RadioConfig | null;
+  onResendMessage?: (messageId: number) => void;
 }
 
 // URL regex for linkifying plain text
@@ -144,14 +145,18 @@ export function MessageList({
   onLoadOlder,
   radioName,
   config,
+  onResendMessage,
 }: MessageListProps) {
   const listRef = useRef<HTMLDivElement>(null);
   const prevMessagesLengthRef = useRef<number>(0);
   const isInitialLoadRef = useRef<boolean>(true);
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+  const [resendPromptMessageId, setResendPromptMessageId] = useState<number | null>(null);
   const [selectedPath, setSelectedPath] = useState<{
     paths: MessagePath[];
     senderInfo: SenderInfo;
+    messageId?: number;
+    canSendAgain?: boolean;
   } | null>(null);
 
   // Capture scroll state in the scroll handler BEFORE any state updates
@@ -304,6 +309,23 @@ export function MessageList({
     };
   };
 
+  const openResendPrompt = useCallback((messageId: number) => {
+    setResendPromptMessageId(messageId);
+  }, []);
+
+  const handleResendConfirm = useCallback(
+    (messageId: number) => {
+      if (!onResendMessage) return;
+      onResendMessage(messageId);
+      setResendPromptMessageId(null);
+    },
+    [onResendMessage]
+  );
+
+  const clearResendPrompt = useCallback(() => {
+    setResendPromptMessageId(null);
+  }, []);
+
   if (loading) {
     return (
       <div className="flex-1 overflow-y-auto p-5 text-center text-muted-foreground">
@@ -385,6 +407,8 @@ export function MessageList({
             }
           }
 
+          const showResendPrompt = resendPromptMessageId === msg.id;
+
           return (
             <div
               key={msg.id}
@@ -464,30 +488,77 @@ export function MessageList({
                     </>
                   )}
                   {msg.outgoing &&
-                    (msg.acked > 0 ? (
-                      msg.paths && msg.paths.length > 0 ? (
-                        <span
-                          className="cursor-pointer hover:text-primary"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setSelectedPath({
-                              paths: msg.paths!,
-                              senderInfo: {
-                                name: config?.name || 'Unknown',
-                                publicKeyOrPrefix: config?.public_key || '',
-                                lat: config?.lat ?? null,
-                                lon: config?.lon ?? null,
-                              },
-                            });
-                          }}
-                          title="View echo paths"
-                        >{` ✓${msg.acked > 1 ? msg.acked : ''}`}</span>
-                      ) : (
-                        ` ✓${msg.acked > 1 ? msg.acked : ''}`
-                      )
-                    ) : (
-                      <span title="No repeats heard yet"> ?</span>
-                    ))}
+                    (() => {
+                      const pathCount = msg.paths?.length ?? 0;
+                      const canSendAgain = pathCount <= 1;
+
+                      if (msg.acked > 0) {
+                        if (msg.paths && msg.paths.length > 0) {
+                          return (
+                            <span
+                              className="cursor-pointer hover:text-primary"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setSelectedPath({
+                                  paths: msg.paths!,
+                                  senderInfo: {
+                                    name: config?.name || 'Unknown',
+                                    publicKeyOrPrefix: config?.public_key || '',
+                                    lat: config?.lat ?? null,
+                                    lon: config?.lon ?? null,
+                                  },
+                                  messageId: msg.id,
+                                  canSendAgain,
+                                });
+                              }}
+                              title="View echo paths"
+                            >{` ✓${msg.acked > 1 ? msg.acked : ''}`}</span>
+                          );
+                        }
+
+                        return ` ✓${msg.acked > 1 ? msg.acked : ''}`;
+                      }
+
+                      if (canSendAgain && onResendMessage) {
+                        return (
+                          <span
+                            className="cursor-pointer hover:text-primary"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              openResendPrompt(msg.id);
+                            }}
+                            title="No repeats heard yet. Try sending again"
+                          >
+                            {' ?'}
+                          </span>
+                        );
+                      }
+
+                      return <span title="No repeats heard yet"> ?</span>;
+                    })()}
+                  {showResendPrompt && (
+                    <span className="ml-2 inline-flex items-center gap-1 text-[10px] text-muted-foreground">
+                      <span>Send again?</span>
+                      <button
+                        className="px-1.5 py-0.5 rounded border border-border hover:bg-accent hover:text-foreground"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleResendConfirm(msg.id);
+                        }}
+                      >
+                        Yes
+                      </button>
+                      <button
+                        className="px-1.5 py-0.5 rounded border border-border hover:bg-accent hover:text-foreground"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          clearResendPrompt();
+                        }}
+                      >
+                        No
+                      </button>
+                    </span>
+                  )}
                 </div>
               </div>
             </div>
@@ -520,16 +591,31 @@ export function MessageList({
       )}
 
       {/* Path modal */}
-      {selectedPath && (
-        <PathModal
-          open={true}
-          onClose={() => setSelectedPath(null)}
-          paths={selectedPath.paths}
-          senderInfo={selectedPath.senderInfo}
-          contacts={contacts}
-          config={config ?? null}
-        />
-      )}
+      {selectedPath && (() => {
+        const resendMessageId = selectedPath.messageId;
+        const canSendAgainFromModal =
+          resendMessageId !== undefined && Boolean(selectedPath.canSendAgain && onResendMessage);
+
+        return (
+          <PathModal
+            open={true}
+            onClose={() => setSelectedPath(null)}
+            paths={selectedPath.paths}
+            senderInfo={selectedPath.senderInfo}
+            contacts={contacts}
+            config={config ?? null}
+            canSendAgain={canSendAgainFromModal}
+            onSendAgain={
+              canSendAgainFromModal
+                ? () => {
+                    setSelectedPath(null);
+                    handleResendConfirm(resendMessageId);
+                  }
+                : undefined
+            }
+          />
+        );
+      })()}
     </div>
   );
 }

--- a/frontend/src/components/PathModal.tsx
+++ b/frontend/src/components/PathModal.tsx
@@ -28,9 +28,20 @@ interface PathModalProps {
   senderInfo: SenderInfo;
   contacts: Contact[];
   config: RadioConfig | null;
+  onSendAgain?: () => void;
+  canSendAgain?: boolean;
 }
 
-export function PathModal({ open, onClose, paths, senderInfo, contacts, config }: PathModalProps) {
+export function PathModal({
+  open,
+  onClose,
+  paths,
+  senderInfo,
+  contacts,
+  config,
+  onSendAgain,
+  canSendAgain = false,
+}: PathModalProps) {
   // Resolve all paths
   const resolvedPaths = paths.map((p) => ({
     ...p,
@@ -116,6 +127,11 @@ export function PathModal({ open, onClose, paths, senderInfo, contacts, config }
         </div>
 
         <DialogFooter>
+          {canSendAgain && onSendAgain && (
+            <Button variant="outline" onClick={onSendAgain}>
+              Send Again
+            </Button>
+          )}
           <Button onClick={onClose}>Close</Button>
         </DialogFooter>
       </DialogContent>

--- a/tests/test_send_messages.py
+++ b/tests/test_send_messages.py
@@ -16,8 +16,9 @@ from app.repository import (
     AppSettingsRepository,
     ChannelRepository,
     ContactRepository,
+    MessageRepository,
 )
-from app.routers.messages import send_channel_message, send_direct_message
+from app.routers.messages import resend_message, send_channel_message, send_direct_message
 
 
 @pytest.fixture
@@ -296,3 +297,92 @@ class TestOutgoingChannelBotTrigger:
         # Fresh message has acked=0
         assert message.id is not None
         assert message.acked == 0
+
+
+class TestResendMessage:
+    """Test re-sending existing outgoing messages without creating duplicates."""
+
+    @pytest.mark.asyncio
+    async def test_resend_direct_uses_original_timestamp_and_tracks_ack(self, test_db):
+        mc = _make_mc()
+        pub_key = "ab" * 32
+        await _insert_contact(pub_key, "Alice")
+        message_id = await MessageRepository.create(
+            msg_type="PRIV",
+            text="retry me",
+            conversation_key=pub_key,
+            sender_timestamp=1700000000,
+            received_at=1700000000,
+            outgoing=True,
+        )
+        assert message_id is not None
+
+        ack_payload = {"expected_ack": b"\x12\x34", "suggested_timeout": 9000}
+        mc.commands.send_msg = AsyncMock(return_value=_make_radio_result(ack_payload))
+
+        with (
+            patch("app.routers.messages.require_connected", return_value=mc),
+            patch("app.routers.messages.track_pending_ack") as mock_track_ack,
+            patch("app.routers.messages.time.time", return_value=1700001234),
+        ):
+            result = await resend_message(message_id)
+
+        assert result == {"status": "ok", "message_id": message_id}
+        send_kwargs = mc.commands.send_msg.await_args.kwargs
+        assert send_kwargs["msg"] == "retry me"
+        assert send_kwargs["timestamp"] == 1700001234
+        mock_track_ack.assert_called_once_with("1234", message_id, 9000)
+        updated = await MessageRepository.get_by_id(message_id)
+        assert updated is not None
+        assert updated.sender_timestamp == 1700001234
+
+    @pytest.mark.asyncio
+    async def test_resend_channel_uses_original_timestamp_bytes(self, test_db):
+        mc = _make_mc(name="MyNode")
+        chan_key = "aa" * 16
+        await ChannelRepository.upsert(key=chan_key, name="#general")
+        message_id = await MessageRepository.create(
+            msg_type="CHAN",
+            text="MyNode: hello again",
+            conversation_key=chan_key.upper(),
+            sender_timestamp=1700000001,
+            received_at=1700000001,
+            outgoing=True,
+        )
+        assert message_id is not None
+
+        with (
+            patch("app.routers.messages.require_connected", return_value=mc),
+            patch("app.routers.messages.asyncio.sleep", new=AsyncMock()),
+            patch("app.routers.messages.time.time", return_value=1700002234),
+        ):
+            result = await resend_message(message_id)
+
+        assert result == {"status": "ok", "message_id": message_id}
+        send_kwargs = mc.commands.send_chan_msg.await_args.kwargs
+        assert send_kwargs["msg"] == "hello again"
+        assert send_kwargs["timestamp"] == (1700002234).to_bytes(4, "little")
+        updated = await MessageRepository.get_by_id(message_id)
+        assert updated is not None
+        assert updated.sender_timestamp == 1700002234
+
+    @pytest.mark.asyncio
+    async def test_resend_rejects_non_outgoing_messages(self, test_db):
+        chan_key = "bb" * 16
+        await ChannelRepository.upsert(key=chan_key, name="#general")
+        message_id = await MessageRepository.create(
+            msg_type="CHAN",
+            text="incoming",
+            conversation_key=chan_key.upper(),
+            sender_timestamp=1700000002,
+            received_at=1700000002,
+            outgoing=False,
+        )
+        assert message_id is not None
+
+        with patch("app.routers.messages.require_connected", return_value=_make_mc()):
+            with pytest.raises(HTTPException) as exc_info:
+                await resend_message(message_id)
+
+        assert exc_info.value.status_code == 400
+        assert "outgoing" in exc_info.value.detail.lower()


### PR DESCRIPTION
## Summary
- add resend endpoint for existing outgoing messages without creating duplicate rows
- add frontend resend actions for no-repeat and single-route scenarios
- add a "Send Again" action in the message path dialog when eligible
- update resend behavior to use a fresh sender timestamp to avoid single-repeater duplicate drops
- add backend tests for resend behavior

## Validation
- PYTHONPATH=. uv run pytest tests/ -v
- cd frontend && npm run test:run && npm run build
