### PR TITLE
Fix settings page scroll lock at browser zoom levels

### DIFF
--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -657,11 +657,11 @@ export function SettingsModal(props: SettingsModalProps) {
   const sectionWrapperClass = 'border border-input rounded-md overflow-hidden';
 
   const sectionContentClass = externalDesktopSidebarMode
-    ? 'space-y-4 p-4 h-full overflow-y-auto'
+    ? 'space-y-4 p-4'
     : 'space-y-4 p-4 border-t border-input';
 
   const settingsContainerClass = externalDesktopSidebarMode
-    ? 'w-full h-full'
+    ? 'w-full h-full overflow-y-auto'
     : 'w-full h-full overflow-y-auto space-y-3';
 
   const sectionButtonClasses =


### PR DESCRIPTION
Fixes an issue where the Settings page could become non-scrollable when browser zoom was increased, causing content to be clipped.

## Root Cause

In settings page mode (externalDesktopSidebarMode), section content used h-full overflow-y-auto without a reliably constrained section height. With parent containers using overflow-hidden, zoomed content could expand past bounds and get clipped instead of scrolling.

## Changes

- Updated settings page-mode container to be the dedicated vertical scroll region.
- Removed section-level h-full overflow-y-auto in page mode so scrolling is handled by the top-level settings container.

## Validation

- PYTHONPATH=. uv run pytest tests/ -v ✅ (430 passed)
- cd frontend && npm run test:run && npm run build ✅ (310 passed, build successful)