### PR TITLE
Remove autoComplete="off" from MessageInput textarea

### DIFF
--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -210,7 +210,6 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
       <div className="flex gap-2 items-end">
         <textarea
           ref={textareaRef}
-          autoComplete="off"
           name="chat-message-input"
           aria-label={placeholder || 'Type a message'}
           data-lpignore="true"


### PR DESCRIPTION
Having autocomplete set to "off" disables the text correction on certain Android browsers/keyboards. In my case specifically with HeliBoard.

I don´t get any weird behavior on the browsers I use (desktop and mobile) with the attribute removed. But if there are certain cases perhaps we can make this conditional? Not having any text correction is pretty annoying.