### PR TITLE
fix: capture push-delivered CLI responses in queue to prevent fetch_contact_cli_response timeout

### DIFF
--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -31,6 +31,11 @@ logger = logging.getLogger(__name__)
 # This prevents handler duplication after reconnects
 _active_subscriptions: list["Subscription"] = []
 
+# Queue for CLI responses (txt_type=1) that arrive as push events.
+# fetch_contact_cli_response drains this before polling get_msg().
+import asyncio as _asyncio
+_cli_response_queue: _asyncio.Queue = _asyncio.Queue()
+
 
 def track_pending_ack(expected_ack: str, message_id: int, timeout_ms: int) -> bool:
     """Compatibility wrapper for pending DM ACK tracking."""
@@ -60,7 +65,8 @@ async def on_contact_message(event: "Event") -> None:
     # Skip CLI command responses (txt_type=1) - these are handled by the command endpoint
     txt_type = payload.get("txt_type", 0)
     if txt_type == 1:
-        logger.debug("Skipping CLI response from %s (txt_type=1)", payload.get("pubkey_prefix"))
+        logger.debug("Queuing CLI response from %s (txt_type=1)", payload.get("pubkey_prefix"))
+        _cli_response_queue.put_nowait(event)
         return
 
     # Get full public key if available, otherwise use prefix

--- a/app/routers/server_control.py
+++ b/app/routers/server_control.py
@@ -14,6 +14,7 @@ from app.models import (
     RepeaterLoginResponse,
 )
 from app.radio_sync import _store_pending_channel_message, _store_pending_direct_message
+from app.event_handlers import _cli_response_queue
 from app.routers.contacts import _ensure_on_radio
 from app.services.radio_runtime import radio_runtime as radio_manager
 
@@ -92,6 +93,17 @@ async def fetch_contact_cli_response(
     deadline = _monotonic() + timeout
 
     while _monotonic() < deadline:
+        # Drain push-delivered CLI responses first before polling get_msg().
+        try:
+            queued = _cli_response_queue.get_nowait()
+            msg_prefix = queued.payload.get("pubkey_prefix", "")
+            txt_type = queued.payload.get("txt_type", 0)
+            if msg_prefix == target_pubkey_prefix and txt_type == 1:
+                logger.debug("CLI response for %s found in push queue", target_pubkey_prefix)
+                return queued
+            logger.debug("Discarding queued CLI response for wrong contact %s", msg_prefix)
+        except asyncio.QueueEmpty:
+            pass
         try:
             result = await mc.commands.get_msg(timeout=2.0)
         except TimeoutError:


### PR DESCRIPTION
## Problem

All repeater CLI commands (get name, get lat, get lon, clock, ver, get radio, 
get tx, get af, get repeat, get flood.max, get advert.interval, 
get flood.advert.interval, get owner.info, get guest.password, and any 
free-form command) consistently time out with:

    WARNING - No CLI response from contact <pubkey> within 20.0s
    WARNING - No response from repeater <pubkey> for command: <cmd>

This causes every repeater detail panel in the UI to fail to populate — 
Node Info, Radio Settings, Advert Intervals, and Owner Info all return empty.

## Root Cause

CLI responses (txt_type=1) from repeaters arrive as unsolicited CONTACT_MSG_RECV 
push events from the firmware. The event dispatcher fans out a clone of each 
event to all active subscribers simultaneously.

Two subscribers compete for each incoming CONTACT_MSG_RECV event:

1. The permanent push subscriber registered in event_handlers.on_contact_message
2. The one-shot future registered by mc.commands.get_msg() inside 
   fetch_contact_cli_response

The permanent subscriber in event_handlers.py explicitly drops txt_type=1 
events (correct behavior — CLI responses should not be stored as chat messages). 
However, fetch_contact_cli_response calls get_msg() in a loop with 2-second 
timeouts, unsubscribing and re-subscribing on each iteration. The push event 
arrives during the gap between two get_msg() iterations — after one call 
unsubscribed its one-shot future and before the next call re-subscribed. The 
permanent event_handlers subscriber is registered at that moment and drops the 
event. When get_msg() re-subscribes and sends command 0x0a to poll the firmware, 
the firmware returns NO_MORE_MSGS because it already delivered the response via 
push. The 20-second timeout then fires.

This was confirmed in logs showing the response arriving and being dropped at 
23:28:14, with the timeout firing at 23:28:33 — 19 seconds into the 20-second 
window with get_msg() actively polling the entire time:

    app.services.dm_ingest - DEBUG - Skipping CLI response from 17ea4a553fa2 (txt_type=1): v1.15.0-dee3e26
    app.event_handlers - DEBUG - Skipping CLI response from 17ea4a553fa2 (txt_type=1)
    app.routers.server_control - WARNING - No CLI response from contact 17ea4a553fa2 within 20.0s

Note: pause_polling=True in radio_operation only pauses the fallback poll loop 
(_polling_pause_count) — it does not block push event delivery. The permanent 
CONTACT_MSG_RECV subscription in event_handlers remains active throughout the 
entire CLI fetch window.

## Fix

Two small changes:

**app/event_handlers.py** — Instead of dropping txt_type=1 push events, put 
them in a module-level asyncio.Queue (_cli_response_queue). The event is still 
not stored as a chat message (the function still returns early), but it is 
preserved for fetch_contact_cli_response to consume.

**app/routers/server_control.py** — At the top of each iteration of the 
fetch_contact_cli_response while loop, drain _cli_response_queue with 
get_nowait() before calling get_msg(). If the queue contains a response for 
the target contact with txt_type=1, return it immediately. If the queue 
contains a response for a different contact, discard it and continue. If the 
queue is empty (QueueEmpty), fall through to the existing get_msg() polling 
path as before.

This means responses captured by the permanent push subscriber are immediately 
available to fetch_contact_cli_response on its very next iteration regardless 
of timing, eliminating the race condition entirely.

## Testing

Tested on a live deployment with a RAK4631 repeater (BethelParkSouth, firmware 
v1.15.0) connected via a Heltec V4 USB companion node on a self-hosted Docker 
stack. All repeater detail panels now populate successfully and immediately:

- Node Info (get name, get lat, get lon, clock) ✓
- Radio Settings (ver, get radio, get tx, get af, get repeat, get flood.max) ✓
- Advert Intervals (get advert.interval, get flood.advert.interval) ✓
- Owner Info (get owner.info, get guest.password) ✓
- Free-form console commands ✓

Confirmed in logs after fix:

    app.event_handlers - DEBUG - Queuing CLI response from 17ea4a553fa2 (txt_type=1)
    app.routers.server_control - DEBUG - CLI response for 17ea4a553fa2 found in push queue

Response is now captured and returned in under 1 second instead of timing out 
after 20 seconds.