### PR TITLE
Fix Web Storage in tests under Node 22+

### DIFF
--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,5 +1,51 @@
 import '@testing-library/jest-dom';
 
+// Node 22+ exposes its own `localStorage`/`sessionStorage` globals, and without
+// `--localstorage-file` they are inert stubs with no Storage methods. Vitest only
+// copies a jsdom window key onto the global when the key is absent from Node's global
+// or appears in its curated key list, and Web Storage is in neither — so Node's stub
+// shadows jsdom's Storage, and every `localStorage.clear()` in a test throws
+// "localStorage.clear is not a function". Vitest also makes `window === globalThis`,
+// so `window.localStorage` resolves to the same stub.
+//
+// Install a spec-shaped in-memory Storage instead of depending on which of the two
+// wins in a given Node version.
+class MemoryStorage implements Storage {
+  #entries = new Map<string, string>();
+
+  get length(): number {
+    return this.#entries.size;
+  }
+
+  key(index: number): string | null {
+    return [...this.#entries.keys()][index] ?? null;
+  }
+
+  getItem(key: string): string | null {
+    return this.#entries.get(String(key)) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.#entries.set(String(key), String(value));
+  }
+
+  removeItem(key: string): void {
+    this.#entries.delete(String(key));
+  }
+
+  clear(): void {
+    this.#entries.clear();
+  }
+}
+
+for (const name of ['localStorage', 'sessionStorage'] as const) {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value: new MemoryStorage(),
+  });
+}
+
 class ResizeObserver {
   observe() {}
   unobserve() {}


### PR DESCRIPTION
## The problem

On Node 22+, 161 tests across 16 files fail with `localStorage.clear is not a function`. Every run also prints ``Warning: `--localstorage-file` was provided without a valid path``.

This is a Node-version interaction in the test environment only; the shipped app is unaffected, and the tests pass on the Node version they were written against.

Three things line up:

1. **Node 22+ defines its own `localStorage`/`sessionStorage` globals.** Without `--localstorage-file` they are inert stubs with no Storage methods (and accessing one emits that warning).
2. **Vitest will not overwrite them.** In `getWindowKeys`, a jsdom window key is copied onto the global only if the key is absent from Node's global *or* appears in vitest's curated `KEYS` list. `localStorage` and `sessionStorage` are in neither `LIVING_KEYS` nor `OTHER_KEYS`, so Node's stub shadows jsdom's `Storage`.
3. **Vitest makes `window === globalThis`**, so `window.localStorage` resolves to the same stub, which is why both spellings in the suite break.

## The change

There is no configuration knob for this: the jsdom environment calls `populateGlobal(global, dom.window, { bindFunctions: true })` with no `additionalKeys` (that list is hardcoded, and only populated for happy-dom). So the fix goes in `src/test/setup.ts`, alongside the existing `ResizeObserver` and `matchMedia` stubs: install a spec-shaped in-memory `Storage` rather than depending on which of the two implementations wins in a given Node version.

The suite only uses `getItem`/`setItem`/`removeItem`/`clear`, with no index access, no `key()`/`length`, no `instanceof Storage`. `MapView` listens for `storage` events, but per spec those fire only in *other* documents, so jsdom never fired them for same-window writes either, and no test dispatches a synthetic one.

## Result

```
before:  701 passed | 161 failed  (16 files failed)
after:   862 passed |   0 failed  (75 files passed)
```

`tsc`, `eslint` (no new warnings), `prettier --check`, and `vite build` all pass. The Node warning is gone as well, since nothing reaches its getter anymore.

## Alternative considered

Vitest sets `global.jsdom = dom`, so `jsdom.window.localStorage` could supply jsdom's real `Storage` instead. That has more faithful semantics, but it couples the setup file to a vitest implementation detail, and falling back when it is absent would make behavior vary by environment. The self-contained version is more predictable; happy to switch if you would rather lean on jsdom's.

## Note

Independent of #339 and #340; it touches only `frontend/src/test/setup.ts` and can land in any order. It is worth landing first if you see these failures locally, since it unmasks the real signal in the other two.