### PR TITLE
feat: MQTT community neighbor reporting

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -213,6 +213,7 @@ Both traffic buckets come from one 24h raw-packet scan (`_packet_shape_24h`) sha
 - The telemetry collection loop in `radio_sync.py` is unified: it iterates over both `tracked_telemetry_repeaters` and `tracked_telemetry_contacts`, dispatching to `_collect_repeater_telemetry` (type 2) or `_collect_contact_telemetry` (others). The daily check ceiling uses the combined count.
 - The 60-second radio stats sampling loop in `radio_stats.py` dispatches an enriched health snapshot (radio identity + full stats) to all fanout modules after each sample.
 - Community MQTT publishes raw packets only, but its derived `path` field for direct packets is emitted as comma-separated hop identifiers, not flat path bytes.
+- Community MQTT can additionally produce canonical neighbor snapshots. `fanout/community_neighbors.py` shares one bounded direct-repeater cache and active discovery/scope-query workflow across all Community MQTT broker slots, then publishes one immutable QoS-1 document to each valid connected slot. Its local `neighbor_self_scopes` config is intentionally explicit; `known_regions` and the active flood scope are not a full flood-permission map.
 - See `app/fanout/AGENTS_fanout.md` for full architecture details and event payload shapes.
 
 ### Web Push notifications
@@ -323,6 +324,9 @@ Web Push is a standalone subsystem in `app/push/`, separate from the fanout modu
 - `POST /fanout` — create new fanout config
 - `PATCH /fanout/{id}` — update fanout config (triggers module reload)
 - `DELETE /fanout/{id}` — delete fanout config (stops module)
+- `GET /fanout/{id}/community-neighbors/status` — shared Community MQTT neighbor cache and scheduling state
+- `POST /fanout/{id}/community-neighbors/discover` — start or join zero-hop repeater discovery without publishing
+- `POST /fanout/{id}/community-neighbors/snapshot` — query cached direct repeaters and publish one QoS-1 snapshot
 - `POST /fanout/bots/disable-until-restart` — stop bot modules and keep bots disabled until restart
 
 ### Statistics
@@ -428,6 +432,7 @@ tests/
 ├── test_channel_sender_backfill.py # Sender-key backfill uniqueness rules for channel messages
 ├── test_channels_router.py     # Channels router endpoints
 ├── test_community_mqtt.py      # Community MQTT publisher (JWT, packet format, hash, broadcast)
+├── test_community_neighbors.py # Community MQTT neighbor cache, scope reporting, QoS, validation
 ├── test_config.py              # Configuration validation
 ├── test_contact_reconciliation_service.py # Prefix/contact reconciliation service helpers
 ├── test_contacts_router.py     # Contacts router endpoints

--- a/app/decoder.py
+++ b/app/decoder.py
@@ -590,6 +590,34 @@ def decrypt_direct_message(payload: bytes, shared_secret: bytes) -> DecryptedDir
     )
 
 
+def decrypt_response_payload(payload: bytes, shared_secret: bytes) -> bytes | None:
+    """Decrypt a normal ``PAYLOAD_TYPE_RESPONSE`` body.
+
+    Responses use the same addressed/MACed AES envelope as direct messages:
+    destination hash, source hash, two-byte HMAC prefix, then AES-ECB blocks.
+    The response plaintext is protocol-specific (for anonymous regions it is
+    ``request_tag | remote_time | scopes``), so callers receive the raw
+    validated plaintext rather than a text-message structure.
+    """
+    if len(payload) < 4:
+        return None
+
+    mac = payload[2:4]
+    ciphertext = payload[4:]
+    if not ciphertext or len(ciphertext) % 16 != 0:
+        return None
+
+    calculated_mac = hmac.new(shared_secret, ciphertext, hashlib.sha256).digest()[:2]
+    if not hmac.compare_digest(calculated_mac, mac):
+        return None
+
+    try:
+        return AES.new(shared_secret[:16], AES.MODE_ECB).decrypt(ciphertext)
+    except Exception as e:
+        logger.debug("AES decryption failed for response payload: %s", e)
+        return None
+
+
 def try_decrypt_dm(
     raw_packet: bytes,
     our_private_key: bytes,

--- a/app/fanout/AGENTS_fanout.md
+++ b/app/fanout/AGENTS_fanout.md
@@ -113,6 +113,10 @@ Wraps `CommunityMqttPublisher` from `app/fanout/community_mqtt.py`. Config blob:
 - Only publishes raw packets (on_message is a no-op)
 - The published `raw` field is always the original packet hex.
 - When a direct packet includes a `path` field, it is emitted as comma-separated hop identifiers exactly as the packet reports them. Token width varies with the packet's path hash mode (`1`, `2`, or `3` bytes per hop); there is no legacy flat per-byte companion field.
+- Optional neighbor reporting is controlled per broker by `neighbor_reporting_enabled` (off by default), `neighbor_reporting_interval_hours` (12–336, default 24), `neighbor_origin`, `neighbor_self_scopes`, `neighbor_topic_template`, and `neighbor_retain`.
+- `community_neighbors.py` owns one bounded 50-repeater cache and one radio workflow shared across all live Community MQTT modules. Passive signed, zero-hop repeater adverts and matching active discovery responses use the same cache; periodic reports collect for 60 seconds, query every frozen neighbor under one 30-second deadline, then publish the same immutable JSON document to every valid connected target at QoS 1.
+- `neighbor_self_scopes` is an explicit operator-maintained comma-separated export of flood-allowed local scopes. Do not derive it from `known_regions` or the current flood-scope setting: those values do not represent the radio's full allow/deny permission map.
+- The three `community-neighbors` API endpoints below expose status, manual non-publishing refresh, and manual snapshot publication. Cache observation is also wired directly into `packet_processor.py` before asynchronous fanout dispatch so fast zero-hop encrypted replies are not lost while MQTT reconnects.
 
 ### bot (bot.py)
 Wraps bot code execution via `app/fanout/bot_exec.py`. Config blob:
@@ -334,6 +338,9 @@ const defaultScopes: Record<string, Record<string, unknown>> = {
 | POST | `/api/fanout` | Create new config |
 | PATCH | `/api/fanout/{id}` | Update config (triggers module reload) |
 | DELETE | `/api/fanout/{id}` | Delete config (stops module) |
+| GET | `/api/fanout/{id}/community-neighbors/status` | Shared cache and report state for a Community MQTT config |
+| POST | `/api/fanout/{id}/community-neighbors/discover` | Start or join a zero-hop refresh without publishing |
+| POST | `/api/fanout/{id}/community-neighbors/snapshot` | Query cached repeaters and publish one snapshot |
 
 ## Database
 
@@ -356,6 +363,7 @@ Migrations:
 - `app/fanout/community_mqtt.py` — CommunityMqttPublisher (community MQTT with JWT auth)
 - `app/fanout/mqtt_private.py` — Private MQTT fanout module
 - `app/fanout/mqtt_community.py` — Community MQTT fanout module
+- `app/fanout/community_neighbors.py` — Shared Community MQTT neighbor cache, discovery, scope queries, scheduling, and snapshot handoff
 - `app/fanout/bot.py` — Bot fanout module
 - `app/fanout/bot_exec.py` — Bot code execution, response processing, rate limiting
 - `app/fanout/webhook.py` — Webhook fanout module

--- a/app/fanout/community_neighbors.py
+++ b/app/fanout/community_neighbors.py
@@ -167,6 +167,29 @@ def _format_snapshot_timestamp(timestamp: int) -> str:
     return datetime.fromtimestamp(timestamp, UTC).isoformat(timespec="microseconds")
 
 
+async def _derive_self_scopes() -> str:
+    """Derive the observer's flood-allowed scopes from RemoteTerm's active flood scope.
+
+    When a regional flood scope is configured, that scope is reported.
+    When no flood scope restriction is active, wildcard '*' is reported
+    (all scopes are flood-allowed).
+    """
+    try:
+        from app.repository import AppSettingsRepository
+
+        app_settings = await AppSettingsRepository.get()
+        flood_scope = app_settings.flood_scope if app_settings else None
+    except Exception:
+        logger.debug("Could not resolve flood scope for neighbor self_scopes", exc_info=True)
+        return "*"
+
+    if not flood_scope or not isinstance(flood_scope, str) or not flood_scope.strip():
+        return "*"
+
+    normalized = normalize_self_scopes(flood_scope)
+    return normalized or "*"
+
+
 class CommunityNeighborReporter:
     """One bounded cache / state machine shared by Community MQTT modules."""
 
@@ -878,7 +901,7 @@ class CommunityNeighborReporter:
             if periodic:
                 self._schedule_next_periodic_cycle()
 
-        serialized = self._build_snapshot(entries, target_ids)
+        serialized = await self._build_snapshot(entries, target_ids)
         if serialized is None:
             async with self._transition_lock:
                 self._last_publish_result = "failed"
@@ -901,7 +924,9 @@ class CommunityNeighborReporter:
 
     # ── Snapshot construction ──────────────────────────────────────────
 
-    def _build_snapshot(self, entries: list[ScopeQueryEntry], target_ids: set[str]) -> str | None:
+    async def _build_snapshot(
+        self, entries: list[ScopeQueryEntry], target_ids: set[str]
+    ) -> str | None:
         try:
             from app.keystore import get_public_key
             from app.services.radio_runtime import radio_runtime
@@ -913,13 +938,12 @@ class CommunityNeighborReporter:
                 )
                 return None
 
-            metadata_module = self._metadata_module(target_ids)
-            config = metadata_module.config if metadata_module is not None else {}
-            origin = normalize_neighbor_origin(config.get("neighbor_origin"))
-            if not origin and radio_runtime.meshcore and radio_runtime.meshcore.self_info:
+            origin = ""
+            if radio_runtime.meshcore and radio_runtime.meshcore.self_info:
                 origin = str(radio_runtime.meshcore.self_info.get("name") or "").strip()
-            origin = origin or "MeshCore Device"
-            self_scopes = normalize_self_scopes(config.get("neighbor_self_scopes", ""))
+            origin = normalize_neighbor_origin(origin) or "MeshCore Device"
+
+            self_scopes = await _derive_self_scopes()
         except (ValueError, TypeError):
             logger.warning(
                 "Cannot build Community MQTT neighbor snapshot: invalid local scope config",
@@ -984,15 +1008,6 @@ class CommunityNeighborReporter:
         if not encoded or len(encoded) >= MAX_SNAPSHOT_BYTES:
             return None
         return serialized
-
-    def _metadata_module(self, target_ids: set[str]) -> CommunityNeighborModule | None:
-        for config_id in sorted(target_ids):
-            module = self._modules.get(config_id)
-            if module is not None:
-                return module
-        for config_id in sorted(self._modules):
-            return self._modules[config_id]
-        return None
 
     # ── Scheduling ─────────────────────────────────────────────────────
 

--- a/app/fanout/community_neighbors.py
+++ b/app/fanout/community_neighbors.py
@@ -1,0 +1,1218 @@
+"""Shared MQTT Community Broker neighbor-reporting coordinator.
+
+The Community MQTT fanout can have several broker configurations, but the
+radio can only perform one useful zero-hop survey at a time.  This coordinator
+therefore owns one bounded neighbour cache and one active report workflow, then
+hands the completed snapshot to every opted-in Community MQTT module.
+
+The radio's companion protocol creates the authenticated anonymous regions
+request for ``CMD_SEND_ANON_REQ``.  The coordinator supplies the target
+identity and an empty path (zero hop), then uses the firmware-generated tag
+from ``MSG_SENT`` to match direct encrypted raw responses (with the generic
+``BINARY_RESPONSE`` event retained as a firmware fallback).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal, Protocol, cast
+
+from meshcore import EventType
+
+from app.decoder import (
+    PayloadType,
+    decrypt_response_payload,
+    derive_shared_secret,
+    parse_advertisement,
+    verify_advert_signature,
+)
+from app.path_utils import parse_packet_envelope
+
+logger = logging.getLogger(__name__)
+
+MAX_NEIGHBORS = 50
+MAX_SCOPE_BYTES = 95
+MAX_SNAPSHOT_BYTES = 10_240
+DISCOVERY_WINDOW_SECONDS = 60.0
+SCOPE_QUERY_TIMEOUT_SECONDS = 30.0
+DEFAULT_PERIODIC_INTERVAL_HOURS = 24
+MIN_PERIODIC_INTERVAL_HOURS = 12
+MAX_PERIODIC_INTERVAL_HOURS = 336
+
+_ANON_REGIONS_REQUEST = 0x01
+_SEND_ANON_REQUEST_COMMAND = 0x39
+
+QueryStatus = Literal["pending", "responded", "timeout", "send_failed"]
+
+
+class NeighborReporterError(RuntimeError):
+    """An operator-actionable neighbor workflow error."""
+
+
+class CommunityNeighborModule(Protocol):
+    """Minimal Community MQTT module contract used by the coordinator."""
+
+    config_id: str
+    config: dict[str, Any]
+
+    @property
+    def neighbor_publisher_connected(self) -> bool: ...
+
+    async def publish_neighbor_snapshot(self, serialized_snapshot: str) -> bool: ...
+
+
+@dataclass(slots=True)
+class NeighborCacheEntry:
+    """One directly heard repeater identity retained across reporting cycles."""
+
+    public_key: str
+    advert_timestamp: int
+    heard_timestamp: int
+    snr_q4: int
+
+
+@dataclass(slots=True)
+class ScopeQueryEntry:
+    """Frozen cache data and one anonymous region-query outcome."""
+
+    public_key: str
+    heard_timestamp: int
+    snr_q4: int
+    request_tag: str | None = None
+    scopes: str = ""
+    status: QueryStatus = "pending"
+
+
+def _wall_time() -> int:
+    """Wrapper around wall time for deterministic tests."""
+    return int(time.time())
+
+
+def _monotonic() -> float:
+    """Wrapper around monotonic time for deterministic tests."""
+    return time.monotonic()
+
+
+def _quantize_snr(snr: object) -> int:
+    """Return signed quarter-dB SNR with truncation toward zero."""
+    try:
+        value = float(cast(Any, snr))
+    except (TypeError, ValueError):
+        value = 0.0
+    return max(-128, min(127, int(value * 4)))
+
+
+def _bounded_scope_text(data: bytes) -> str:
+    """Decode one peer scope string safely using the canonical 95-byte cap."""
+    bounded = data[:MAX_SCOPE_BYTES]
+    text = bounded.decode("utf-8", errors="ignore").split("\x00", 1)[0]
+    # Scope strings are data, never commands.  Keep normal printable Unicode
+    # but reject remaining control characters before JSON serialization.
+    return "".join(char for char in text if char >= " " or char == "\t")
+
+
+def normalize_self_scopes(value: object) -> str:
+    """Normalize explicit local flood-allowed scopes into canonical CSV text.
+
+    The companion protocol does not expose the local firmware's entire region
+    permission map.  Community MQTT configs therefore carry this explicit
+    operator-maintained export instead of incorrectly treating ``known_regions``
+    (a decoder candidate list) as a permission list.
+    """
+    raw_values: list[str]
+    if isinstance(value, str):
+        raw_values = value.split(",")
+    elif isinstance(value, list):
+        raw_values = [str(v) for v in value]
+    elif value is None:
+        raw_values = []
+    else:
+        raise ValueError("neighbor_self_scopes must be a comma-separated string or list")
+
+    scopes: list[str] = []
+    for raw in raw_values:
+        if not isinstance(raw, str):
+            raise ValueError("neighbor_self_scopes entries must be strings")
+        scope = raw.strip().replace("\x00", "")
+        if scope.startswith("#"):
+            scope = scope[1:]
+        if not scope:
+            continue
+        if any(ord(char) < 32 for char in scope):
+            raise ValueError("neighbor_self_scopes cannot contain control characters")
+        scopes.append(scope)
+
+    return ",".join(scopes)
+
+
+def normalize_neighbor_origin(value: object) -> str:
+    """Normalize the optional configured snapshot origin name."""
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ValueError("neighbor_origin must be a string")
+    origin = value.strip()
+    if len(origin) >= 2 and origin[0] == origin[-1] and origin[0] in {'"', "'"}:
+        origin = origin[1:-1].strip()
+    return origin
+
+
+def _format_snapshot_timestamp(timestamp: int) -> str:
+    """Return the strict neighbor-schema UTC timestamp (not the packet ``Z`` form)."""
+    return datetime.fromtimestamp(timestamp, UTC).isoformat(timespec="microseconds")
+
+
+class CommunityNeighborReporter:
+    """One bounded cache / state machine shared by Community MQTT modules."""
+
+    def __init__(self, *, cache_limit: int = MAX_NEIGHBORS) -> None:
+        self._cache_limit = max(1, cache_limit)
+        self._cache: dict[str, NeighborCacheEntry] = {}
+        self._modules: dict[str, CommunityNeighborModule] = {}
+        self._seen_observation_ids: set[object] = set()
+        self._seen_observation_order: list[object] = []
+
+        self._transition_lock = asyncio.Lock()
+        self._task: asyncio.Task[None] | None = None
+
+        self._last_tag = 0
+        self._discovery_tag: int | None = None
+        self._discovery_deadline: float | None = None
+        self._discovery_subscription: Any = None
+        # A radio can report a direct discovery response immediately after its
+        # host command is accepted.  The window is deliberately armed only
+        # after transmit, so retain matching events received in that tiny
+        # handoff interval and replay them once the deadline exists.
+        self._early_discovery_responses: list[dict[str, Any]] = []
+        self._discovery_periodic = False
+        self._discovery_manual_scope = False
+        self._discovery_target_ids: set[str] = set()
+
+        self._scope_active = False
+        self._scope_deadline: float | None = None
+        self._scope_entries: list[ScopeQueryEntry] = []
+        self._queries_by_tag: dict[str, ScopeQueryEntry] = {}
+        # A very fast zero-hop response can be logged before the companion
+        # host reports MSG_SENT and reveals its request tag. Keep a bounded
+        # overlay buffer so that race is retried as soon as the tag exists.
+        self._early_scope_responses: list[bytes] = []
+        self._scope_periodic = False
+        self._scope_target_ids: set[str] = set()
+        # A completed scope phase hands one immutable document to MQTT.  Keep
+        # that handoff serialized so a second manual request cannot overtake
+        # or mutate an earlier snapshot while it is being published.
+        self._publishing_snapshot = False
+
+        self._next_periodic_at: float | None = None
+        self._last_publish_result: Literal["ok", "failed"] | None = None
+
+    # ── Module lifecycle ──────────────────────────────────────────────
+
+    async def register_module(self, module: CommunityNeighborModule) -> None:
+        """Make a live Community MQTT module eligible for shared reporting."""
+        self._modules[module.config_id] = module
+        self._ensure_task()
+        await self._ensure_periodic_schedule()
+
+    async def unregister_module(self, config_id: str) -> None:
+        """Remove a module without discarding cache state for other brokers."""
+        self._modules.pop(config_id, None)
+        if self._modules:
+            await self._ensure_periodic_schedule()
+            return
+
+        await self._reset_when_unused()
+
+    def _ensure_task(self) -> None:
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._run(), name="community-mqtt-neighbors")
+
+    async def _reset_when_unused(self) -> None:
+        async with self._transition_lock:
+            self._clear_discovery_subscription()
+            self._discovery_tag = None
+            self._discovery_deadline = None
+            self._early_discovery_responses = []
+            self._discovery_periodic = False
+            self._discovery_manual_scope = False
+            self._discovery_target_ids.clear()
+            self._scope_active = False
+            self._scope_deadline = None
+            self._scope_entries = []
+            self._queries_by_tag = {}
+            self._early_scope_responses = []
+            self._scope_target_ids.clear()
+            self._scope_periodic = False
+            self._publishing_snapshot = False
+            self._next_periodic_at = None
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        self._task = None
+
+    # ── Passive cache population ───────────────────────────────────────
+
+    async def observe_raw_packet(self, data: dict[str, Any]) -> None:
+        """Adapt a fanout raw-packet event into the shared radio observer."""
+        raw_hex = data.get("data")
+        if not isinstance(raw_hex, str):
+            return
+        try:
+            raw = bytes.fromhex(raw_hex)
+        except ValueError:
+            return
+        await self.observe_packet(
+            raw,
+            timestamp=data.get("timestamp"),
+            measured_snr=data.get("snr"),
+            observation_id=data.get("observation_id"),
+        )
+
+    async def observe_packet(
+        self,
+        raw: bytes,
+        *,
+        timestamp: object = None,
+        measured_snr: object = None,
+        observation_id: object = None,
+    ) -> None:
+        """Observe one raw RF packet for passive adverts or active responses.
+
+        ``packet_processor`` calls this before asynchronous fanout dispatch so
+        active response matching does not depend on a broker task being
+        scheduled promptly.  ``observe_raw_packet`` calls it too; the bounded
+        observation-id set makes that duplicate delivery harmless.
+        """
+        if observation_id is not None:
+            async with self._transition_lock:
+                if observation_id in self._seen_observation_ids:
+                    return
+                self._remember_observation_id(observation_id)
+
+        envelope = parse_packet_envelope(raw)
+        if envelope is None:
+            return
+        if envelope.payload_type == int(PayloadType.RESPONSE):
+            await self._observe_scope_response_packet(
+                envelope.payload,
+                envelope.hop_count,
+                envelope.route_type,
+            )
+            return
+        if envelope.payload_type != int(PayloadType.ADVERT):
+            return
+        if envelope.hop_count != 0:
+            return
+        # A local Share advert uses zero transport codes and does not establish
+        # a radio neighbor relationship.
+        if envelope.transport_codes == (0, 0):
+            return
+
+        advert = parse_advertisement(envelope.payload, raw_packet=raw)
+        if advert is None or advert.device_role != 2:
+            return
+        if not verify_advert_signature(envelope.payload):
+            return
+
+        heard_timestamp = int(timestamp) if isinstance(timestamp, (int, float)) else _wall_time()
+        await self.put_neighbor(
+            advert.public_key,
+            advert_timestamp=advert.timestamp,
+            measured_snr=measured_snr,
+            heard_timestamp=heard_timestamp,
+        )
+
+    async def put_neighbor(
+        self,
+        public_key: str,
+        *,
+        advert_timestamp: int,
+        measured_snr: object,
+        heard_timestamp: int | None = None,
+    ) -> None:
+        """Insert/update one cache entry, evicting the least recently heard entry."""
+        normalized_key = public_key.lower()
+        if len(normalized_key) != 64:
+            return
+        try:
+            bytes.fromhex(normalized_key)
+        except ValueError:
+            return
+        if normalized_key == self._local_public_key_hex():
+            return
+
+        entry = NeighborCacheEntry(
+            public_key=normalized_key,
+            advert_timestamp=max(0, int(advert_timestamp)),
+            heard_timestamp=max(
+                0, int(_wall_time() if heard_timestamp is None else heard_timestamp)
+            ),
+            snr_q4=_quantize_snr(measured_snr),
+        )
+        async with self._transition_lock:
+            if normalized_key not in self._cache and len(self._cache) >= self._cache_limit:
+                victim = min(
+                    self._cache.values(),
+                    key=lambda existing: (existing.heard_timestamp, existing.public_key),
+                )
+                self._cache.pop(victim.public_key, None)
+            self._cache[normalized_key] = entry
+
+    async def remove_neighbor(self, public_key: str) -> bool:
+        """Explicitly remove a cached neighbor by full 64-char hex public key.
+
+        Returns ``True`` when the key was present and removed, ``False`` when
+        the key was not in the cache.
+        """
+        normalized_key = public_key.lower()
+        async with self._transition_lock:
+            return self._cache.pop(normalized_key, None) is not None
+
+    async def clear_neighbors(self) -> int:
+        """Remove all cached neighbors and return the count cleared."""
+        async with self._transition_lock:
+            count = len(self._cache)
+            self._cache.clear()
+            return count
+
+    @staticmethod
+    def _local_public_key_hex() -> str | None:
+        """Return the local identity when key export has completed, if any."""
+        try:
+            from app.keystore import get_public_key
+
+            public_key = get_public_key()
+        except Exception:
+            logger.debug("Could not resolve local identity for neighbor reporting", exc_info=True)
+            return None
+        if public_key is None or len(public_key) != 32:
+            return None
+        return public_key.hex().lower()
+
+    def _remember_observation_id(self, observation_id: object) -> None:
+        self._seen_observation_ids.add(observation_id)
+        self._seen_observation_order.append(observation_id)
+        while len(self._seen_observation_order) > 256:
+            expired = self._seen_observation_order.pop(0)
+            self._seen_observation_ids.discard(expired)
+
+    # ── Manual operations ──────────────────────────────────────────────
+
+    async def start_manual_discovery(self, config_id: str) -> dict[str, Any]:
+        """Start (or join) the canonical 60-second zero-hop discovery window."""
+        self._require_registered_module(config_id)
+        async with self._transition_lock:
+            if self._scope_active:
+                return {"status": "active", "message": "A scope snapshot is already in progress"}
+            if self._discovery_tag is not None:
+                return self._refresh_status("joined")
+
+        await self._begin_discovery(periodic=False, target_ids=set(self._modules))
+        return self._refresh_status("started")
+
+    async def start_manual_snapshot(self, config_id: str) -> dict[str, Any]:
+        """Publish a scope snapshot now, or queue it behind an active refresh."""
+        module = self._require_registered_module(config_id)
+        if not module.neighbor_publisher_connected:
+            raise NeighborReporterError("Community MQTT bridge is not running")
+
+        async with self._transition_lock:
+            if self._scope_active:
+                self._scope_target_ids.update(
+                    self._eligible_publish_target_ids(set(self._modules), include_manual=True)
+                )
+                return {"status": "active", "message": "Scope snapshot already in progress"}
+            if self._publishing_snapshot:
+                return {
+                    "status": "active",
+                    "message": "Previous scope snapshot is still publishing",
+                }
+            if self._discovery_tag is not None:
+                self._discovery_manual_scope = True
+                self._discovery_target_ids.update(set(self._modules))
+                return self._refresh_status("queued")
+
+        await self._begin_scope_queries(target_ids=set(self._modules), periodic=False, manual=True)
+        return {"status": "started", "message": "Scope snapshot started"}
+
+    def _require_registered_module(self, config_id: str) -> CommunityNeighborModule:
+        module = self._modules.get(config_id)
+        if module is None:
+            raise NeighborReporterError("Community MQTT integration is disabled or not running")
+        return module
+
+    def _refresh_status(self, status: str) -> dict[str, Any]:
+        remaining = 0
+        if self._discovery_deadline is not None:
+            remaining = max(0, int(self._discovery_deadline - _monotonic() + 0.999))
+        return {
+            "status": status,
+            "message": f"Zero-hop discovery active ({remaining}s remaining)",
+            "remaining_seconds": remaining,
+        }
+
+    # ── Active zero-hop discovery ──────────────────────────────────────
+
+    def _next_tag(self) -> int:
+        candidate = _wall_time() & 0xFFFFFFFF
+        if candidate == 0 or candidate <= self._last_tag:
+            candidate = (self._last_tag + 1) & 0xFFFFFFFF
+            if candidate == 0:
+                candidate = 1
+        self._last_tag = candidate
+        return candidate
+
+    async def _begin_discovery(self, *, periodic: bool, target_ids: set[str]) -> None:
+        async with self._transition_lock:
+            if self._discovery_tag is not None or self._scope_active:
+                return
+            tag = self._next_tag()
+            self._discovery_tag = tag
+            # Reserve the workflow while waiting for the shared radio lock,
+            # but do not consume the canonical 60-second RF collection window
+            # before the request has actually been handed to the radio.
+            self._discovery_deadline = None
+            self._early_discovery_responses = []
+            self._discovery_periodic = periodic
+            self._discovery_target_ids = set(target_ids)
+            self._discovery_manual_scope = False
+
+        try:
+            from app.services.radio_runtime import radio_runtime
+
+            async with radio_runtime.radio_operation("community_neighbor_discovery") as mc:
+                subscription = mc.subscribe(
+                    EventType.DISCOVER_RESPONSE, self._on_discovery_response
+                )
+                async with self._transition_lock:
+                    # The workflow may have been cancelled while waiting for the
+                    # shared radio lock.  Avoid leaving a stray listener behind.
+                    if self._discovery_tag != tag:
+                        subscription.unsubscribe()
+                        return
+                    self._discovery_subscription = subscription
+
+                result = await mc.commands.send_node_discover_req(
+                    1 << 2,
+                    prefix_only=False,
+                    tag=tag,
+                    since=0,
+                )
+                if result is None or result.type == EventType.ERROR:
+                    raise NeighborReporterError("Failed to start zero-hop neighbor discovery")
+
+                async with self._transition_lock:
+                    if self._discovery_tag != tag:
+                        return
+                    self._discovery_deadline = _monotonic() + DISCOVERY_WINDOW_SECONDS
+                    early_responses = list(self._early_discovery_responses)
+                    self._early_discovery_responses = []
+
+                # Responses can arrive between transmit and the host command's
+                # completion event.  They are still part of this collection
+                # window, so validate them after atomically arming it.
+                for payload in early_responses:
+                    await self._observe_discovery_response(payload)
+        except Exception as exc:
+            async with self._transition_lock:
+                if self._discovery_tag == tag:
+                    self._clear_discovery_subscription()
+                    self._discovery_tag = None
+                    self._discovery_deadline = None
+                    self._early_discovery_responses = []
+                    self._discovery_periodic = False
+                    self._discovery_manual_scope = False
+                    self._discovery_target_ids.clear()
+                    if periodic:
+                        self._schedule_next_periodic_cycle()
+            if isinstance(exc, NeighborReporterError):
+                raise
+            raise NeighborReporterError(
+                f"Failed to start zero-hop neighbor discovery: {exc}"
+            ) from exc
+
+    async def _on_discovery_response(self, event: Any) -> None:
+        """Validate and merge a matching direct repeater discovery response."""
+        payload = getattr(event, "payload", {})
+        if not isinstance(payload, dict):
+            return
+        await self._observe_discovery_response(payload)
+
+    async def _observe_discovery_response(self, payload: dict[str, Any]) -> None:
+        """Process one discovery payload, buffering only the send handoff race."""
+        public_key: str | None = None
+
+        async with self._transition_lock:
+            tag = self._discovery_tag
+            deadline = self._discovery_deadline
+            if tag is None:
+                return
+            path_byte = payload.get("path_len")
+            if (
+                payload.get("node_type") != 2
+                or isinstance(path_byte, bool)
+                or not isinstance(path_byte, int)
+                or not 0 <= path_byte <= 0xFF
+                or path_byte & 0x3F
+            ):
+                return
+            event_tag = payload.get("tag")
+            expected_tag = tag.to_bytes(4, "little", signed=False).hex()
+            if not isinstance(event_tag, str) or event_tag.lower() != expected_tag:
+                return
+            candidate_key = payload.get("pubkey")
+            if not isinstance(candidate_key, str) or len(candidate_key) != 64:
+                return
+            try:
+                if len(bytes.fromhex(candidate_key)) != 32:
+                    return
+            except ValueError:
+                return
+            if deadline is None:
+                self._remember_early_discovery_response(payload)
+                return
+            if _monotonic() >= deadline:
+                return
+            public_key = candidate_key
+
+        try:
+            from app.keystore import get_public_key
+
+            if public_key is None:
+                return
+            own_key = get_public_key()
+            if own_key is not None and public_key.lower() == own_key.hex().lower():
+                return
+        except Exception:
+            logger.debug("Could not resolve local identity for discovery response", exc_info=True)
+
+        await self.put_neighbor(
+            public_key,
+            advert_timestamp=_wall_time(),
+            measured_snr=payload.get("SNR"),
+        )
+
+    def _remember_early_discovery_response(self, payload: dict[str, Any]) -> None:
+        """Keep a bounded copy of matching events received during transmit."""
+        self._early_discovery_responses.append(dict(payload))
+        del self._early_discovery_responses[:-64]
+
+    async def _observe_scope_response_packet(
+        self, payload: bytes, hop_count: int, route_type: int
+    ) -> None:
+        """Match one raw encrypted direct response through the temporary overlay.
+
+        The normal contact table deliberately remains untouched: cached direct
+        repeaters are not necessarily contacts and adding them would consume
+        finite radio slots.  Instead, while a scope batch is active we try only
+        in-flight identities whose compact source hash matches the packet, then
+        accept it only after authenticated decryption and an exact request-tag
+        match.  Normal ACL traffic is merely observed, never intercepted.
+        """
+        if route_type != 0x02 or hop_count != 0 or len(payload) < 4:
+            return
+
+        try:
+            from app.keystore import get_private_key, get_public_key
+
+            private_key = get_private_key()
+            public_key = get_public_key()
+        except Exception:
+            logger.debug("Could not load local key for neighbor response overlay", exc_info=True)
+            return
+        if private_key is None or public_key is None or len(public_key) != 32:
+            return
+        if payload[0] != public_key[0]:
+            return
+
+        source_hash = payload[1]
+        candidates: list[ScopeQueryEntry] = []
+        has_unassigned_candidate = False
+        async with self._transition_lock:
+            if not self._scope_active:
+                return
+            for entry in self._scope_entries:
+                if entry.status != "pending":
+                    continue
+                try:
+                    candidate_key = bytes.fromhex(entry.public_key)
+                except ValueError:
+                    continue
+                if candidate_key[0] != source_hash:
+                    continue
+                if entry.request_tag is None:
+                    has_unassigned_candidate = True
+                else:
+                    candidates.append(entry)
+            if not candidates and not has_unassigned_candidate:
+                return
+
+        for entry in candidates:
+            try:
+                shared_secret = derive_shared_secret(private_key, bytes.fromhex(entry.public_key))
+            except Exception:
+                continue
+            plaintext = decrypt_response_payload(payload, shared_secret)
+            if plaintext is None:
+                continue
+            if await self._accept_scope_response(entry, plaintext):
+                return
+
+        # Do not lose a response that arrived while its host-side MSG_SENT
+        # acknowledgement was still being delivered.  It will be retried once
+        # that request's expected-ack tag is known.
+        if has_unassigned_candidate:
+            async with self._transition_lock:
+                if self._scope_active:
+                    self._remember_early_scope_response(payload)
+
+    async def _accept_scope_response(self, entry: ScopeQueryEntry, plaintext: bytes) -> bool:
+        """Validate and record a decrypted response, returning whether it matched."""
+        if len(plaintext) < 8:
+            return False
+
+        should_finish = False
+        async with self._transition_lock:
+            if (
+                not self._scope_active
+                or entry.status != "pending"
+                or entry.request_tag is None
+                or plaintext[:4].hex().lower() != entry.request_tag
+            ):
+                return False
+            entry.scopes = _bounded_scope_text(plaintext[8:])
+            entry.status = "responded"
+            should_finish = all(item.status != "pending" for item in self._scope_entries)
+
+        if should_finish:
+            await self._finish_scope_queries(timeout=False)
+        return True
+
+    def _remember_early_scope_response(self, payload: bytes) -> None:
+        if payload in self._early_scope_responses:
+            return
+        self._early_scope_responses.append(payload)
+        del self._early_scope_responses[:-64]
+
+    async def _replay_early_scope_responses(self) -> None:
+        """Retry raw responses buffered during command/MSG_SENT handoff."""
+        async with self._transition_lock:
+            if not self._scope_active or not self._early_scope_responses:
+                return
+            packets = list(self._early_scope_responses)
+            self._early_scope_responses.clear()
+        for payload in packets:
+            await self._observe_scope_response_packet(payload, 0, 0x02)
+
+    # ── Anonymous scope query batch ────────────────────────────────────
+
+    async def _begin_scope_queries(
+        self,
+        *,
+        target_ids: set[str],
+        periodic: bool,
+        manual: bool = False,
+    ) -> None:
+        local_key = self._local_public_key_hex()
+        async with self._transition_lock:
+            if self._scope_active:
+                self._scope_target_ids.update(target_ids)
+                return
+            if self._publishing_snapshot:
+                if periodic:
+                    self._schedule_next_periodic_cycle()
+                    return
+                raise NeighborReporterError("Previous scope snapshot is still publishing")
+
+            eligible_targets = self._eligible_publish_target_ids(target_ids, include_manual=manual)
+            if not self._has_connected_target(eligible_targets):
+                if periodic:
+                    self._schedule_next_periodic_cycle()
+                    return
+                raise NeighborReporterError("Community MQTT bridge is not running")
+
+            # Packets may arrive before radio key export completes.  Once the
+            # local identity is available, prune any such transient self-advert
+            # before freezing query entries so the observer can never query or
+            # publish itself as a neighbor.
+            if local_key is not None:
+                self._cache.pop(local_key, None)
+
+            entries = [
+                ScopeQueryEntry(
+                    public_key=entry.public_key,
+                    heard_timestamp=entry.heard_timestamp,
+                    snr_q4=entry.snr_q4,
+                )
+                for entry in self._cache.values()
+                if entry.heard_timestamp > 0
+            ]
+            self._scope_active = True
+            # Reserve entries before the radio lock is acquired so raw replies
+            # can be matched as soon as their host-side tags arrive.  The
+            # shared 30-second response deadline starts only after this one
+            # pass has handed every request to the radio.
+            self._scope_deadline = None
+            self._scope_entries = entries
+            self._queries_by_tag = {}
+            self._early_scope_responses = []
+            self._scope_periodic = periodic
+            # Keep every enabled eligible slot in the frozen handoff.  A slot
+            # that reconnects during the shared 30-second RF phase must still
+            # receive this snapshot if it is connected when publication starts.
+            self._scope_target_ids = set(eligible_targets)
+
+        # Zero neighbours is a valid immediate snapshot; do not wait for a
+        # deadline or touch the radio.
+        if not entries:
+            await self._finish_scope_queries(timeout=False)
+            return
+
+        try:
+            from app.services.radio_runtime import radio_runtime
+
+            async with radio_runtime.radio_operation("community_neighbor_scopes") as mc:
+                # The radio host protocol acknowledges command queueing one at
+                # a time.  Complete this one pass first; only then begin the
+                # shared 30-second response window, so waiting for the radio
+                # lock or host queue never steals RF reply time.
+                for entry in entries:
+                    result = await self._send_regions_request(mc, entry.public_key)
+                    if result is None or result.type != EventType.MSG_SENT:
+                        entry.status = "send_failed"
+                        continue
+                    expected_ack = (
+                        result.payload.get("expected_ack")
+                        if isinstance(result.payload, dict)
+                        else None
+                    )
+                    if not isinstance(expected_ack, (bytes, bytearray)) or len(expected_ack) != 4:
+                        entry.status = "send_failed"
+                        continue
+                    tag = bytes(expected_ack).hex().lower()
+                    mapped = False
+                    async with self._transition_lock:
+                        # Tags are firmware-generated and should be unique.  A
+                        # collision cannot safely identify a response, so expose
+                        # it as a send failure rather than misattribute data.
+                        if tag in self._queries_by_tag:
+                            entry.status = "send_failed"
+                        else:
+                            entry.request_tag = tag
+                            self._queries_by_tag[tag] = entry
+                            mapped = True
+                    if mapped:
+                        await self._replay_early_scope_responses()
+                        async with self._transition_lock:
+                            if not self._scope_active:
+                                return
+
+                async with self._transition_lock:
+                    if self._scope_active and any(entry.status == "pending" for entry in entries):
+                        self._scope_deadline = _monotonic() + SCOPE_QUERY_TIMEOUT_SECONDS
+        except Exception:
+            logger.warning("Community neighbor scope request batch failed", exc_info=True)
+            for entry in entries:
+                if entry.status == "pending":
+                    entry.status = "send_failed"
+
+        if all(entry.status != "pending" for entry in entries):
+            await self._finish_scope_queries(timeout=False)
+
+    async def _send_regions_request(self, mc: Any, public_key: str) -> Any:
+        """Queue one firmware-authenticated zero-hop anonymous regions request.
+
+        ``CMD_SEND_ANON_REQ`` receives the full target identity and an empty
+        reverse-path descriptor.  Firmware derives the pairwise secret, writes
+        the canonical six-byte inner payload, and later returns the request tag
+        as ``expected_ack`` in ``MSG_SENT``.
+        """
+        try:
+            target = bytes.fromhex(public_key)
+        except ValueError:
+            return None
+        command = bytes((_SEND_ANON_REQUEST_COMMAND,)) + target + bytes((_ANON_REGIONS_REQUEST, 0))
+        try:
+            return await mc.commands.send(
+                command,
+                [EventType.MSG_SENT, EventType.ERROR],
+                timeout=1.0,
+            )
+        except Exception:
+            logger.debug(
+                "Could not queue anonymous regions request for %s", public_key[:12], exc_info=True
+            )
+            return None
+
+    async def _finish_scope_queries(self, *, timeout: bool) -> None:
+        """Freeze outcomes, build canonical JSON, and publish to all targets."""
+        async with self._transition_lock:
+            if not self._scope_active:
+                return
+            if not timeout and any(entry.status == "pending" for entry in self._scope_entries):
+                return
+            if timeout:
+                for entry in self._scope_entries:
+                    if entry.status == "pending":
+                        entry.status = "timeout"
+
+            entries = list(self._scope_entries)
+            target_ids = set(self._scope_target_ids)
+            periodic = self._scope_periodic
+            self._scope_active = False
+            self._scope_deadline = None
+            self._scope_entries = []
+            self._queries_by_tag = {}
+            self._early_scope_responses = []
+            self._scope_target_ids.clear()
+            self._scope_periodic = False
+            self._publishing_snapshot = True
+            if periodic:
+                self._schedule_next_periodic_cycle()
+
+        serialized = self._build_snapshot(entries, target_ids)
+        if serialized is None:
+            async with self._transition_lock:
+                self._last_publish_result = "failed"
+                self._publishing_snapshot = False
+            return
+
+        accepted = False
+        for config_id in sorted(target_ids):
+            module = self._modules.get(config_id)
+            if module is None or not module.neighbor_publisher_connected:
+                continue
+            try:
+                accepted = (await module.publish_neighbor_snapshot(serialized)) or accepted
+            except Exception:
+                logger.warning("Community neighbor publish failed for %s", config_id, exc_info=True)
+
+        async with self._transition_lock:
+            self._last_publish_result = "ok" if accepted else "failed"
+            self._publishing_snapshot = False
+
+    # ── Snapshot construction ──────────────────────────────────────────
+
+    def _build_snapshot(self, entries: list[ScopeQueryEntry], target_ids: set[str]) -> str | None:
+        try:
+            from app.keystore import get_public_key
+            from app.services.radio_runtime import radio_runtime
+
+            public_key = get_public_key()
+            if public_key is None or len(public_key) != 32:
+                logger.warning(
+                    "Cannot build Community MQTT neighbor snapshot without local public key"
+                )
+                return None
+
+            metadata_module = self._metadata_module(target_ids)
+            config = metadata_module.config if metadata_module is not None else {}
+            origin = normalize_neighbor_origin(config.get("neighbor_origin"))
+            if not origin and radio_runtime.meshcore and radio_runtime.meshcore.self_info:
+                origin = str(radio_runtime.meshcore.self_info.get("name") or "").strip()
+            origin = origin or "MeshCore Device"
+            self_scopes = normalize_self_scopes(config.get("neighbor_self_scopes", ""))
+        except (ValueError, TypeError):
+            logger.warning(
+                "Cannot build Community MQTT neighbor snapshot: invalid local scope config",
+                exc_info=True,
+            )
+            return None
+        except Exception:
+            logger.warning("Cannot build Community MQTT neighbor snapshot", exc_info=True)
+            return None
+
+        now = _wall_time()
+        local_key_hex = public_key.hex().lower()
+        neighbor_data = [
+            {
+                "pubkey": entry.public_key.upper(),
+                "snr": entry.snr_q4 / 4.0,
+                "heard_secs_ago": max(0, now - entry.heard_timestamp),
+                "scopes": entry.scopes,
+                "status": entry.status,
+            }
+            for entry in entries
+            if entry.public_key.lower() != local_key_hex
+        ]
+        neighbor_data.sort(
+            key=lambda item: (
+                item["heard_secs_ago"],
+                -float(item["snr"]),
+                str(item["pubkey"]),
+            )
+        )
+
+        root: dict[str, Any] = {
+            "timestamp": _format_snapshot_timestamp(now),
+            "origin": origin,
+            "origin_id": public_key.hex().upper(),
+            "self": {"scopes": self_scopes},
+            "neighbors": [],
+        }
+
+        serialized = self._serialize_snapshot(root)
+        if serialized is None:
+            return None
+        for neighbor in neighbor_data:
+            root["neighbors"].append(neighbor)
+            candidate = self._serialize_snapshot(root)
+            if candidate is None:
+                root["neighbors"].pop()
+                break
+            serialized = candidate
+        return serialized
+
+    @staticmethod
+    def _serialize_snapshot(snapshot: dict[str, Any]) -> str | None:
+        try:
+            serialized = json.dumps(snapshot, ensure_ascii=False, separators=(",", ":"))
+        except (TypeError, ValueError):
+            return None
+        encoded = serialized.encode("utf-8")
+        # The fixed-buffer interoperability profile reserves no byte for a
+        # document that reaches the buffer boundary: accepted JSON must be
+        # strictly smaller than the 10,240-byte snapshot buffer.
+        if not encoded or len(encoded) >= MAX_SNAPSHOT_BYTES:
+            return None
+        return serialized
+
+    def _metadata_module(self, target_ids: set[str]) -> CommunityNeighborModule | None:
+        for config_id in sorted(target_ids):
+            module = self._modules.get(config_id)
+            if module is not None:
+                return module
+        for config_id in sorted(self._modules):
+            return self._modules[config_id]
+        return None
+
+    # ── Scheduling ─────────────────────────────────────────────────────
+
+    async def _run(self) -> None:
+        try:
+            while self._modules:
+                await self._tick()
+                await asyncio.sleep(0.5)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Community MQTT neighbor reporter stopped unexpectedly")
+
+    async def _tick(self) -> None:
+        now = _monotonic()
+        start_scope: tuple[set[str], bool, bool] | None = None
+        start_periodic = False
+        async with self._transition_lock:
+            periodic_ids = self._periodic_target_ids()
+            if not periodic_ids:
+                self._next_periodic_at = None
+                if (
+                    self._discovery_tag is not None
+                    and self._discovery_periodic
+                    and not self._discovery_manual_scope
+                ):
+                    self._clear_discovery_subscription()
+                    self._discovery_tag = None
+                    self._discovery_deadline = None
+                    self._early_discovery_responses = []
+                    self._discovery_periodic = False
+                    self._discovery_target_ids.clear()
+
+            if (
+                self._discovery_tag is not None
+                and self._discovery_deadline is not None
+                and now >= self._discovery_deadline
+            ):
+                target_ids = set(self._discovery_target_ids)
+                periodic = self._discovery_periodic
+                manual_scope = self._discovery_manual_scope
+                self._clear_discovery_subscription()
+                self._discovery_tag = None
+                self._discovery_deadline = None
+                self._early_discovery_responses = []
+                self._discovery_periodic = False
+                self._discovery_manual_scope = False
+                self._discovery_target_ids.clear()
+                if manual_scope or periodic:
+                    start_scope = (target_ids, periodic, manual_scope)
+
+            # A due periodic cycle joins a manually started collection window
+            # rather than wasting an additional discovery broadcast.  The
+            # existing window still has the canonical tag/deadline; only its
+            # completion ownership changes to include the periodic snapshot.
+            if (
+                self._discovery_tag is not None
+                and not self._discovery_periodic
+                and periodic_ids
+                and self._next_periodic_at is not None
+                and now >= self._next_periodic_at
+                and self._has_connected_target(periodic_ids)
+            ):
+                self._discovery_periodic = True
+                self._discovery_target_ids.update(periodic_ids)
+
+            if (
+                self._scope_active
+                and self._scope_deadline is not None
+                and now >= self._scope_deadline
+            ):
+                # Finish outside the lock; it reacquires it and atomically
+                # marks all still-pending entries as timeouts.
+                pass
+            elif (
+                self._discovery_tag is None
+                and not self._scope_active
+                and periodic_ids
+                and self._next_periodic_at is not None
+                and now >= self._next_periodic_at
+                and self._has_connected_target(periodic_ids)
+            ):
+                start_periodic = True
+
+        if self._scope_active and self._scope_deadline is not None and now >= self._scope_deadline:
+            await self._finish_scope_queries(timeout=True)
+            return
+        if start_scope is not None:
+            target_ids, periodic, manual = start_scope
+            try:
+                await self._begin_scope_queries(
+                    target_ids=target_ids,
+                    periodic=periodic,
+                    manual=manual,
+                )
+            except NeighborReporterError:
+                logger.debug("Skipping unavailable Community MQTT scope phase", exc_info=True)
+            return
+        if start_periodic:
+            try:
+                await self._begin_discovery(periodic=True, target_ids=self._periodic_target_ids())
+            except NeighborReporterError:
+                logger.debug(
+                    "Periodic Community MQTT neighbor refresh could not start", exc_info=True
+                )
+                async with self._transition_lock:
+                    self._schedule_next_periodic_cycle()
+
+    async def _ensure_periodic_schedule(self) -> None:
+        async with self._transition_lock:
+            if self._periodic_target_ids():
+                # A newly enabled periodic reporter is due immediately once a
+                # broker connection exists; it does not wait a full day first.
+                # When a shorter-interval module joins alongside an existing one,
+                # bring the next-run forward so the min-interval policy is
+                # honoured from the first cycle onward.
+                desired = _monotonic()
+                if self._next_periodic_at is None or desired < self._next_periodic_at:
+                    self._next_periodic_at = desired
+            else:
+                self._next_periodic_at = None
+
+    def _periodic_target_ids(self) -> set[str]:
+        return {
+            config_id
+            for config_id, module in self._modules.items()
+            if bool(module.config.get("neighbor_reporting_enabled", False))
+        }
+
+    def _eligible_publish_target_ids(
+        self, target_ids: set[str], *, include_manual: bool
+    ) -> set[str]:
+        """Return enabled Community slots eligible for this snapshot handoff.
+
+        Connection state is checked only to decide whether a new RF workflow is
+        useful and again at publish time.  It must not remove a temporarily
+        disconnected target from an already-started snapshot.
+        """
+        if include_manual:
+            candidates = set(target_ids)
+        else:
+            candidates = self._periodic_target_ids() & set(target_ids)
+        return {config_id for config_id in candidates if self._modules.get(config_id) is not None}
+
+    def _has_connected_target(self, target_ids: set[str]) -> bool:
+        return any(
+            module.neighbor_publisher_connected
+            for config_id, module in self._modules.items()
+            if config_id in target_ids
+        )
+
+    def _periodic_interval_seconds(self) -> float:
+        intervals: list[int] = []
+        for config_id in self._periodic_target_ids():
+            module = self._modules.get(config_id)
+            if module is None:
+                continue
+            try:
+                hours = int(
+                    module.config.get(
+                        "neighbor_reporting_interval_hours", DEFAULT_PERIODIC_INTERVAL_HOURS
+                    )
+                )
+            except (TypeError, ValueError):
+                hours = DEFAULT_PERIODIC_INTERVAL_HOURS
+            intervals.append(
+                max(MIN_PERIODIC_INTERVAL_HOURS, min(MAX_PERIODIC_INTERVAL_HOURS, hours))
+            )
+        return min(intervals, default=DEFAULT_PERIODIC_INTERVAL_HOURS) * 3600.0
+
+    def _schedule_next_periodic_cycle(self) -> None:
+        if self._periodic_target_ids():
+            self._next_periodic_at = _monotonic() + self._periodic_interval_seconds()
+        else:
+            self._next_periodic_at = None
+
+    # ── Diagnostics and cleanup ────────────────────────────────────────
+
+    def status_for(self, config_id: str) -> dict[str, Any]:
+        """Return lightweight operational state for the config's UI/API surface."""
+        now = _monotonic()
+        if self._publishing_snapshot:
+            phase = "publishing"
+            remaining = None
+        elif self._scope_active:
+            phase = "scopes"
+            remaining = max(0, int((self._scope_deadline or now) - now + 0.999))
+        elif self._discovery_tag is not None:
+            phase = "refresh"
+            remaining = max(0, int((self._discovery_deadline or now) - now + 0.999))
+        elif self._next_periodic_at is not None:
+            remaining = max(0, int(self._next_periodic_at - now + 0.999))
+            # A periodic reporter stays due until a connected MQTT slot lets
+            # it open its canonical discovery window.  Keeping this distinct
+            # from a future scheduled run makes a disconnected bridge visible
+            # to the operator without changing the workflow.
+            phase = "due" if remaining == 0 else "scheduled"
+        else:
+            phase = "idle"
+            remaining = None
+        module = self._modules.get(config_id)
+        return {
+            "phase": phase,
+            "cache_size": len(self._cache),
+            "remaining_seconds": remaining,
+            "periodic_enabled": bool(
+                module and module.config.get("neighbor_reporting_enabled", False)
+            ),
+            "last_publish_result": self._last_publish_result,
+        }
+
+    def _clear_discovery_subscription(self) -> None:
+        if self._discovery_subscription is not None:
+            try:
+                self._discovery_subscription.unsubscribe()
+            except Exception:
+                logger.debug("Could not remove neighbor discovery listener", exc_info=True)
+        self._discovery_subscription = None
+
+
+# One coordinator is deliberately shared across every Community MQTT fanout
+# config.  See module docstring for why this is not module-local state.
+community_neighbor_reporter = CommunityNeighborReporter()

--- a/app/fanout/community_neighbors.py
+++ b/app/fanout/community_neighbors.py
@@ -6,10 +6,11 @@ therefore owns one bounded neighbour cache and one active report workflow, then
 hands the completed snapshot to every opted-in Community MQTT module.
 
 The radio's companion protocol creates the authenticated anonymous regions
-request for ``CMD_SEND_ANON_REQ``.  The coordinator supplies the target
-identity and an empty path (zero hop), then uses the firmware-generated tag
-from ``MSG_SENT`` to match direct encrypted raw responses (with the generic
-``BINARY_RESPONSE`` event retained as a firmware fallback).
+request for ``CMD_SEND_ANON_REQ``. The coordinator supplies the target identity
+and an empty path (zero hop), then uses the firmware-generated tag from
+``MSG_SENT`` to match direct encrypted raw responses. Raw matching is required
+because the companion exposes only one host-side pending binary response while
+a neighbor snapshot queries several peers as one concurrent batch.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -103,7 +105,9 @@ def _quantize_snr(snr: object) -> int:
     try:
         value = float(cast(Any, snr))
     except (TypeError, ValueError):
-        value = 0.0
+        return 0
+    if not math.isfinite(value):
+        return 0
     return max(-128, min(127, int(value * 4)))
 
 
@@ -113,7 +117,7 @@ def _bounded_scope_text(data: bytes) -> str:
     text = bounded.decode("utf-8", errors="ignore").split("\x00", 1)[0]
     # Scope strings are data, never commands.  Keep normal printable Unicode
     # but reject remaining control characters before JSON serialization.
-    return "".join(char for char in text if char >= " " or char == "\t")
+    return "".join(char for char in text if char >= " ")
 
 
 def normalize_self_scopes(value: object) -> str:
@@ -128,7 +132,9 @@ def normalize_self_scopes(value: object) -> str:
     if isinstance(value, str):
         raw_values = value.split(",")
     elif isinstance(value, list):
-        raw_values = [str(v) for v in value]
+        if not all(isinstance(item, str) for item in value):
+            raise ValueError("neighbor_self_scopes entries must be strings")
+        raw_values = value
     elif value is None:
         raw_values = []
     else:
@@ -136,15 +142,13 @@ def normalize_self_scopes(value: object) -> str:
 
     scopes: list[str] = []
     for raw in raw_values:
-        if not isinstance(raw, str):
-            raise ValueError("neighbor_self_scopes entries must be strings")
-        scope = raw.strip().replace("\x00", "")
+        scope = raw.strip()
+        if any(ord(char) < 32 for char in scope):
+            raise ValueError("neighbor_self_scopes cannot contain control characters")
         if scope.startswith("#"):
             scope = scope[1:]
         if not scope:
             continue
-        if any(ord(char) < 32 for char in scope):
-            raise ValueError("neighbor_self_scopes cannot contain control characters")
         scopes.append(scope)
 
     return ",".join(scopes)
@@ -159,35 +163,14 @@ def normalize_neighbor_origin(value: object) -> str:
     origin = value.strip()
     if len(origin) >= 2 and origin[0] == origin[-1] and origin[0] in {'"', "'"}:
         origin = origin[1:-1].strip()
+    if any(ord(char) < 32 for char in origin):
+        raise ValueError("neighbor_origin cannot contain control characters")
     return origin
 
 
 def _format_snapshot_timestamp(timestamp: int) -> str:
     """Return the strict neighbor-schema UTC timestamp (not the packet ``Z`` form)."""
     return datetime.fromtimestamp(timestamp, UTC).isoformat(timespec="microseconds")
-
-
-async def _derive_self_scopes() -> str:
-    """Derive the observer's flood-allowed scopes from RemoteTerm's active flood scope.
-
-    When a regional flood scope is configured, that scope is reported.
-    When no flood scope restriction is active, wildcard '*' is reported
-    (all scopes are flood-allowed).
-    """
-    try:
-        from app.repository import AppSettingsRepository
-
-        app_settings = await AppSettingsRepository.get()
-        flood_scope = app_settings.flood_scope if app_settings else None
-    except Exception:
-        logger.debug("Could not resolve flood scope for neighbor self_scopes", exc_info=True)
-        return "*"
-
-    if not flood_scope or not isinstance(flood_scope, str) or not flood_scope.strip():
-        return "*"
-
-    normalized = normalize_self_scopes(flood_scope)
-    return normalized or "*"
 
 
 class CommunityNeighborReporter:
@@ -197,8 +180,6 @@ class CommunityNeighborReporter:
         self._cache_limit = max(1, cache_limit)
         self._cache: dict[str, NeighborCacheEntry] = {}
         self._modules: dict[str, CommunityNeighborModule] = {}
-        self._seen_observation_ids: set[object] = set()
-        self._seen_observation_order: list[object] = []
 
         self._transition_lock = asyncio.Lock()
         self._task: asyncio.Task[None] | None = None
@@ -213,13 +194,13 @@ class CommunityNeighborReporter:
         # handoff interval and replay them once the deadline exists.
         self._early_discovery_responses: list[dict[str, Any]] = []
         self._discovery_periodic = False
+        self._discovery_manual = False
         self._discovery_manual_scope = False
         self._discovery_target_ids: set[str] = set()
 
         self._scope_active = False
         self._scope_deadline: float | None = None
         self._scope_entries: list[ScopeQueryEntry] = []
-        self._queries_by_tag: dict[str, ScopeQueryEntry] = {}
         # A very fast zero-hop response can be logged before the companion
         # host reports MSG_SENT and reveals its request tag. Keep a bounded
         # overlay buffer so that race is retried as soon as the tag exists.
@@ -262,12 +243,12 @@ class CommunityNeighborReporter:
             self._discovery_deadline = None
             self._early_discovery_responses = []
             self._discovery_periodic = False
+            self._discovery_manual = False
             self._discovery_manual_scope = False
             self._discovery_target_ids.clear()
             self._scope_active = False
             self._scope_deadline = None
             self._scope_entries = []
-            self._queries_by_tag = {}
             self._early_scope_responses = []
             self._scope_target_ids.clear()
             self._scope_periodic = False
@@ -283,43 +264,14 @@ class CommunityNeighborReporter:
 
     # ── Passive cache population ───────────────────────────────────────
 
-    async def observe_raw_packet(self, data: dict[str, Any]) -> None:
-        """Adapt a fanout raw-packet event into the shared radio observer."""
-        raw_hex = data.get("data")
-        if not isinstance(raw_hex, str):
-            return
-        try:
-            raw = bytes.fromhex(raw_hex)
-        except ValueError:
-            return
-        await self.observe_packet(
-            raw,
-            timestamp=data.get("timestamp"),
-            measured_snr=data.get("snr"),
-            observation_id=data.get("observation_id"),
-        )
-
     async def observe_packet(
         self,
         raw: bytes,
         *,
         timestamp: object = None,
         measured_snr: object = None,
-        observation_id: object = None,
     ) -> None:
-        """Observe one raw RF packet for passive adverts or active responses.
-
-        ``packet_processor`` calls this before asynchronous fanout dispatch so
-        active response matching does not depend on a broker task being
-        scheduled promptly.  ``observe_raw_packet`` calls it too; the bounded
-        observation-id set makes that duplicate delivery harmless.
-        """
-        if observation_id is not None:
-            async with self._transition_lock:
-                if observation_id in self._seen_observation_ids:
-                    return
-                self._remember_observation_id(observation_id)
-
+        """Observe one raw RF packet for passive adverts or active responses."""
         envelope = parse_packet_envelope(raw)
         if envelope is None:
             return
@@ -420,13 +372,6 @@ class CommunityNeighborReporter:
             return None
         return public_key.hex().lower()
 
-    def _remember_observation_id(self, observation_id: object) -> None:
-        self._seen_observation_ids.add(observation_id)
-        self._seen_observation_order.append(observation_id)
-        while len(self._seen_observation_order) > 256:
-            expired = self._seen_observation_order.pop(0)
-            self._seen_observation_ids.discard(expired)
-
     # ── Manual operations ──────────────────────────────────────────────
 
     async def start_manual_discovery(self, config_id: str) -> dict[str, Any]:
@@ -436,6 +381,7 @@ class CommunityNeighborReporter:
             if self._scope_active:
                 return {"status": "active", "message": "A scope snapshot is already in progress"}
             if self._discovery_tag is not None:
+                self._discovery_manual = True
                 return self._refresh_status("joined")
 
         await self._begin_discovery(periodic=False, target_ids=set(self._modules))
@@ -443,8 +389,8 @@ class CommunityNeighborReporter:
 
     async def start_manual_snapshot(self, config_id: str) -> dict[str, Any]:
         """Publish a scope snapshot now, or queue it behind an active refresh."""
-        module = self._require_registered_module(config_id)
-        if not module.neighbor_publisher_connected:
+        self._require_registered_module(config_id)
+        if not self._has_connected_target(set(self._modules)):
             raise NeighborReporterError("Community MQTT bridge is not running")
 
         async with self._transition_lock:
@@ -459,6 +405,7 @@ class CommunityNeighborReporter:
                     "message": "Previous scope snapshot is still publishing",
                 }
             if self._discovery_tag is not None:
+                self._discovery_manual = True
                 self._discovery_manual_scope = True
                 self._discovery_target_ids.update(set(self._modules))
                 return self._refresh_status("queued")
@@ -497,6 +444,12 @@ class CommunityNeighborReporter:
         async with self._transition_lock:
             if self._discovery_tag is not None or self._scope_active:
                 return
+            if periodic and not self._scope_crypto_available():
+                self._last_publish_result = "failed"
+                self._schedule_next_periodic_cycle()
+                raise NeighborReporterError(
+                    "Periodic neighbor reporting requires the radio private key"
+                )
             tag = self._next_tag()
             self._discovery_tag = tag
             # Reserve the workflow while waiting for the shared radio lock,
@@ -505,13 +458,16 @@ class CommunityNeighborReporter:
             self._discovery_deadline = None
             self._early_discovery_responses = []
             self._discovery_periodic = periodic
+            self._discovery_manual = not periodic
             self._discovery_target_ids = set(target_ids)
             self._discovery_manual_scope = False
 
         try:
             from app.services.radio_runtime import radio_runtime
 
-            async with radio_runtime.radio_operation("community_neighbor_discovery") as mc:
+            async with radio_runtime.radio_operation(
+                "community_neighbor_discovery", pause_polling=True, suspend_auto_fetch=True
+            ) as mc:
                 subscription = mc.subscribe(
                     EventType.DISCOVER_RESPONSE, self._on_discovery_response
                 )
@@ -552,6 +508,7 @@ class CommunityNeighborReporter:
                     self._discovery_deadline = None
                     self._early_discovery_responses = []
                     self._discovery_periodic = False
+                    self._discovery_manual = False
                     self._discovery_manual_scope = False
                     self._discovery_target_ids.clear()
                     if periodic:
@@ -584,6 +541,7 @@ class CommunityNeighborReporter:
                 or isinstance(path_byte, bool)
                 or not isinstance(path_byte, int)
                 or not 0 <= path_byte <= 0xFF
+                or path_byte >> 6 == 3
                 or path_byte & 0x3F
             ):
                 return
@@ -640,7 +598,7 @@ class CommunityNeighborReporter:
         accept it only after authenticated decryption and an exact request-tag
         match.  Normal ACL traffic is merely observed, never intercepted.
         """
-        if route_type != 0x02 or hop_count != 0 or len(payload) < 4:
+        if route_type != 0x02 or hop_count != 0 or len(payload) < 20:
             return
 
         try:
@@ -751,16 +709,22 @@ class CommunityNeighborReporter:
                 return
             if self._publishing_snapshot:
                 if periodic:
-                    self._schedule_next_periodic_cycle()
+                    self._next_periodic_at = _monotonic()
                     return
                 raise NeighborReporterError("Previous scope snapshot is still publishing")
 
             eligible_targets = self._eligible_publish_target_ids(target_ids, include_manual=manual)
             if not self._has_connected_target(eligible_targets):
+                if manual:
+                    self._last_publish_result = "failed"
                 if periodic:
-                    self._schedule_next_periodic_cycle()
-                    return
-                raise NeighborReporterError("Community MQTT bridge is not running")
+                    # A periodic run remains due until a broker is available.
+                    # Do not postpone it for a full reporting interval because
+                    # the connection dropped during the discovery window.
+                    self._next_periodic_at = _monotonic()
+                if manual:
+                    raise NeighborReporterError("Community MQTT bridge is not running")
+                return
 
             # Packets may arrive before radio key export completes.  Once the
             # local identity is available, prune any such transient self-advert
@@ -778,6 +742,15 @@ class CommunityNeighborReporter:
                 for entry in self._cache.values()
                 if entry.heard_timestamp > 0
             ]
+            if entries and not self._scope_crypto_available():
+                self._last_publish_result = "failed"
+                if periodic:
+                    self._schedule_next_periodic_cycle()
+                if manual:
+                    raise NeighborReporterError(
+                        "Neighbor scope discovery requires the radio private key"
+                    )
+                return
             self._scope_active = True
             # Reserve entries before the radio lock is acquired so raw replies
             # can be matched as soon as their host-side tags arrive.  The
@@ -785,7 +758,6 @@ class CommunityNeighborReporter:
             # pass has handed every request to the radio.
             self._scope_deadline = None
             self._scope_entries = entries
-            self._queries_by_tag = {}
             self._early_scope_responses = []
             self._scope_periodic = periodic
             # Keep every enabled eligible slot in the frozen handoff.  A slot
@@ -802,7 +774,9 @@ class CommunityNeighborReporter:
         try:
             from app.services.radio_runtime import radio_runtime
 
-            async with radio_runtime.radio_operation("community_neighbor_scopes") as mc:
+            async with radio_runtime.radio_operation(
+                "community_neighbor_scopes", pause_polling=True, suspend_auto_fetch=True
+            ) as mc:
                 # The radio host protocol acknowledges command queueing one at
                 # a time.  Complete this one pass first; only then begin the
                 # shared 30-second response window, so waiting for the radio
@@ -820,23 +794,18 @@ class CommunityNeighborReporter:
                     if not isinstance(expected_ack, (bytes, bytearray)) or len(expected_ack) != 4:
                         entry.status = "send_failed"
                         continue
-                    tag = bytes(expected_ack).hex().lower()
-                    mapped = False
+                    entry.request_tag = bytes(expected_ack).hex().lower()
                     async with self._transition_lock:
-                        # Tags are firmware-generated and should be unique.  A
-                        # collision cannot safely identify a response, so expose
-                        # it as a send failure rather than misattribute data.
-                        if tag in self._queries_by_tag:
-                            entry.status = "send_failed"
-                        else:
-                            entry.request_tag = tag
-                            self._queries_by_tag[tag] = entry
-                            mapped = True
-                    if mapped:
-                        await self._replay_early_scope_responses()
-                        async with self._transition_lock:
-                            if not self._scope_active:
-                                return
+                        if not self._scope_active:
+                            return
+                    # A tag only has to identify the request for this peer. The
+                    # authenticated sender identity disambiguates equal tags
+                    # used by different neighbors, so no global tag map is
+                    # needed.
+                    await self._replay_early_scope_responses()
+                    async with self._transition_lock:
+                        if not self._scope_active:
+                            return
 
                 async with self._transition_lock:
                     if self._scope_active and any(entry.status == "pending" for entry in entries):
@@ -893,7 +862,6 @@ class CommunityNeighborReporter:
             self._scope_active = False
             self._scope_deadline = None
             self._scope_entries = []
-            self._queries_by_tag = {}
             self._early_scope_responses = []
             self._scope_target_ids.clear()
             self._scope_periodic = False
@@ -901,32 +869,32 @@ class CommunityNeighborReporter:
             if periodic:
                 self._schedule_next_periodic_cycle()
 
-        serialized = await self._build_snapshot(entries, target_ids)
-        if serialized is None:
-            async with self._transition_lock:
-                self._last_publish_result = "failed"
-                self._publishing_snapshot = False
-            return
-
         accepted = False
-        for config_id in sorted(target_ids):
-            module = self._modules.get(config_id)
-            if module is None or not module.neighbor_publisher_connected:
-                continue
-            try:
-                accepted = (await module.publish_neighbor_snapshot(serialized)) or accepted
-            except Exception:
-                logger.warning("Community neighbor publish failed for %s", config_id, exc_info=True)
+        try:
+            serialized = self._build_snapshot(entries, target_ids)
+            if serialized is None:
+                return
 
-        async with self._transition_lock:
-            self._last_publish_result = "ok" if accepted else "failed"
-            self._publishing_snapshot = False
+            for config_id in sorted(target_ids):
+                module = self._modules.get(config_id)
+                if module is None or not module.neighbor_publisher_connected:
+                    continue
+                try:
+                    accepted = (await module.publish_neighbor_snapshot(serialized)) or accepted
+                except Exception:
+                    logger.warning(
+                        "Community neighbor publish failed for %s", config_id, exc_info=True
+                    )
+        except Exception:
+            logger.exception("Community neighbor snapshot handoff failed")
+        finally:
+            async with self._transition_lock:
+                self._last_publish_result = "ok" if accepted else "failed"
+                self._publishing_snapshot = False
 
     # ── Snapshot construction ──────────────────────────────────────────
 
-    async def _build_snapshot(
-        self, entries: list[ScopeQueryEntry], target_ids: set[str]
-    ) -> str | None:
+    def _build_snapshot(self, entries: list[ScopeQueryEntry], target_ids: set[str]) -> str | None:
         try:
             from app.keystore import get_public_key
             from app.services.radio_runtime import radio_runtime
@@ -938,12 +906,13 @@ class CommunityNeighborReporter:
                 )
                 return None
 
-            origin = ""
-            if radio_runtime.meshcore and radio_runtime.meshcore.self_info:
-                origin = str(radio_runtime.meshcore.self_info.get("name") or "").strip()
-            origin = normalize_neighbor_origin(origin) or "MeshCore Device"
-
-            self_scopes = await _derive_self_scopes()
+            metadata_module = self._metadata_module(target_ids)
+            config = metadata_module.config if metadata_module is not None else {}
+            origin = normalize_neighbor_origin(config.get("neighbor_origin"))
+            if not origin and radio_runtime.meshcore and radio_runtime.meshcore.self_info:
+                origin = normalize_neighbor_origin(radio_runtime.meshcore.self_info.get("name"))
+            origin = origin or "MeshCore Device"
+            self_scopes = normalize_self_scopes(config.get("neighbor_self_scopes", ""))
         except (ValueError, TypeError):
             logger.warning(
                 "Cannot build Community MQTT neighbor snapshot: invalid local scope config",
@@ -999,9 +968,9 @@ class CommunityNeighborReporter:
     def _serialize_snapshot(snapshot: dict[str, Any]) -> str | None:
         try:
             serialized = json.dumps(snapshot, ensure_ascii=False, separators=(",", ":"))
-        except (TypeError, ValueError):
+            encoded = serialized.encode("utf-8")
+        except (TypeError, ValueError, UnicodeError):
             return None
-        encoded = serialized.encode("utf-8")
         # The fixed-buffer interoperability profile reserves no byte for a
         # document that reaches the buffer boundary: accepted JSON must be
         # strictly smaller than the 10,240-byte snapshot buffer.
@@ -1009,37 +978,70 @@ class CommunityNeighborReporter:
             return None
         return serialized
 
+    def _metadata_module(self, target_ids: set[str]) -> CommunityNeighborModule | None:
+        for config_id in sorted(target_ids):
+            module = self._modules.get(config_id)
+            if module is not None:
+                return module
+        for config_id in sorted(self._modules):
+            return self._modules[config_id]
+        return None
+
+    @staticmethod
+    def _scope_crypto_available() -> bool:
+        """Whether host-side response authentication can be performed."""
+        try:
+            from app.keystore import get_private_key, get_public_key
+
+            private_key = get_private_key()
+            public_key = get_public_key()
+        except Exception:
+            logger.debug("Could not resolve local keys for neighbor scope discovery", exc_info=True)
+            return False
+        return (
+            isinstance(private_key, bytes)
+            and len(private_key) == 64
+            and isinstance(public_key, bytes)
+            and len(public_key) == 32
+        )
+
     # ── Scheduling ─────────────────────────────────────────────────────
 
     async def _run(self) -> None:
-        try:
-            while self._modules:
+        while self._modules:
+            try:
                 await self._tick()
-                await asyncio.sleep(0.5)
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.exception("Community MQTT neighbor reporter stopped unexpectedly")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Community MQTT neighbor reporter tick failed")
+            await asyncio.sleep(0.5)
 
     async def _tick(self) -> None:
         now = _monotonic()
         start_scope: tuple[set[str], bool, bool] | None = None
         start_periodic = False
+        scope_timed_out = False
         async with self._transition_lock:
             periodic_ids = self._periodic_target_ids()
             if not periodic_ids:
                 self._next_periodic_at = None
-                if (
-                    self._discovery_tag is not None
-                    and self._discovery_periodic
-                    and not self._discovery_manual_scope
-                ):
-                    self._clear_discovery_subscription()
-                    self._discovery_tag = None
-                    self._discovery_deadline = None
-                    self._early_discovery_responses = []
-                    self._discovery_periodic = False
-                    self._discovery_target_ids.clear()
+                if self._discovery_tag is not None and self._discovery_periodic:
+                    if self._discovery_manual:
+                        # Keep a manually owned discovery window alive, but
+                        # remove periodic ownership so disabling reporting does
+                        # not turn a manual discover-only request into a scope
+                        # query and MQTT publication at expiry.
+                        self._discovery_periodic = False
+                    else:
+                        self._clear_discovery_subscription()
+                        self._discovery_tag = None
+                        self._discovery_deadline = None
+                        self._early_discovery_responses = []
+                        self._discovery_periodic = False
+                        self._discovery_manual = False
+                        self._discovery_manual_scope = False
+                        self._discovery_target_ids.clear()
 
             if (
                 self._discovery_tag is not None
@@ -1054,6 +1056,7 @@ class CommunityNeighborReporter:
                 self._discovery_deadline = None
                 self._early_discovery_responses = []
                 self._discovery_periodic = False
+                self._discovery_manual = False
                 self._discovery_manual_scope = False
                 self._discovery_target_ids.clear()
                 if manual_scope or periodic:
@@ -1074,17 +1077,15 @@ class CommunityNeighborReporter:
                 self._discovery_periodic = True
                 self._discovery_target_ids.update(periodic_ids)
 
-            if (
+            scope_timed_out = (
                 self._scope_active
                 and self._scope_deadline is not None
                 and now >= self._scope_deadline
-            ):
-                # Finish outside the lock; it reacquires it and atomically
-                # marks all still-pending entries as timeouts.
-                pass
-            elif (
+            )
+            if not scope_timed_out and (
                 self._discovery_tag is None
                 and not self._scope_active
+                and not self._publishing_snapshot
                 and periodic_ids
                 and self._next_periodic_at is not None
                 and now >= self._next_periodic_at
@@ -1092,7 +1093,7 @@ class CommunityNeighborReporter:
             ):
                 start_periodic = True
 
-        if self._scope_active and self._scope_deadline is not None and now >= self._scope_deadline:
+        if scope_timed_out:
             await self._finish_scope_queries(timeout=True)
             return
         if start_scope is not None:

--- a/app/fanout/mqtt_base.py
+++ b/app/fanout/mqtt_base.py
@@ -118,12 +118,27 @@ class BaseMqttPublisher(ABC):
         await self.stop()
         await self.start(settings)
 
-    async def publish(self, topic: str, payload: dict[str, Any], *, retain: bool = False) -> None:
-        """Publish a JSON payload. Drops silently if not connected."""
+    async def publish(
+        self,
+        topic: str,
+        payload: dict[str, Any] | str | bytes,
+        *,
+        retain: bool = False,
+        qos: int = 0,
+    ) -> bool:
+        """Publish one payload and report whether the client accepted it.
+
+        Existing fanout publishers send dictionaries and retain the historical
+        QoS-0 default.  Community-neighbor snapshots are already serialized
+        JSON documents and require QoS 1, so this shared boundary also accepts
+        text/bytes without double-encoding them.
+        """
         if self._client is None or not self.connected:
-            return
+            return False
         try:
-            await self._client.publish(topic, json.dumps(payload), retain=retain)
+            encoded_payload = json.dumps(payload) if isinstance(payload, dict) else payload
+            await self._client.publish(topic, encoded_payload, retain=retain, qos=qos)
+            return True
         except Exception as e:
             logger.warning(
                 "%s publish failed on %s. This is usually transient network noise; "
@@ -138,6 +153,7 @@ class BaseMqttPublisher(ABC):
             # Wake the connection loop so it exits the wait and reconnects
             self._settings_version += 1
             self._version_event.set()
+            return False
 
     # ── Abstract hooks ─────────────────────────────────────────────────
 

--- a/app/fanout/mqtt_community.py
+++ b/app/fanout/mqtt_community.py
@@ -31,59 +31,60 @@ _NEIGHBOR_TOPIC_TEMPLATE_FIELD_CANONICAL = {
 }
 
 
-def _normalize_topic_template(topic_template: str) -> str:
-    """Normalize packet topic template fields to canonical uppercase placeholders."""
-    template = topic_template.strip() or _DEFAULT_PACKET_TOPIC_TEMPLATE
+def _normalize_template(
+    topic_template: str,
+    *,
+    default: str,
+    fields: dict[str, str],
+    label: str,
+    required_suffixes: tuple[str, ...] = (),
+) -> str:
+    """Normalize one topic template using a shared placeholder contract."""
+    template = topic_template.strip() or default
     parts: list[str] = []
-    try:
-        parsed = string.Formatter().parse(template)
-        for literal_text, field_name, format_spec, conversion in parsed:
-            parts.append(literal_text)
-            if field_name is None:
-                continue
-            normalized_field = _TOPIC_TEMPLATE_FIELD_CANONICAL.get(field_name.lower())
-            if normalized_field is None:
-                raise ValueError(f"Unsupported topic template field(s): {field_name}")
-            replacement = ["{", normalized_field]
-            if conversion:
-                replacement.extend(["!", conversion])
-            if format_spec:
-                replacement.extend([":", format_spec])
-            replacement.append("}")
-            parts.append("".join(replacement))
-    except ValueError:
-        raise
+    for literal_text, field_name, format_spec, conversion in string.Formatter().parse(template):
+        # Formatter.parse() unescapes doubled braces in literal text. Escape
+        # them again so the normalized template can safely be formatted later.
+        parts.append(literal_text.replace("{", "{{").replace("}", "}}"))
+        if field_name is None:
+            continue
+        normalized_field = fields.get(field_name.lower())
+        if normalized_field is None:
+            raise ValueError(f"Unsupported {label} topic template field(s): {field_name}")
+        if conversion or format_spec:
+            raise ValueError(f"{label.capitalize()} topic placeholders do not support formatting")
+        parts.append(f"{{{normalized_field}}}")
 
-    return "".join(parts)
+    normalized = "".join(parts)
+    if any(ord(char) < 32 for char in normalized):
+        raise ValueError(f"{label.capitalize()} topic templates cannot contain control characters")
+    if "+" in normalized or "#" in normalized:
+        raise ValueError(f"{label.capitalize()} publish topics cannot contain MQTT wildcards")
+    if required_suffixes and not normalized.endswith(required_suffixes):
+        suffix_text = " or ".join(required_suffixes)
+        raise ValueError(f"{label.capitalize()} topic templates must end with {suffix_text}")
+    return normalized
+
+
+def _normalize_topic_template(topic_template: str) -> str:
+    """Normalize packet topic template fields to canonical placeholders."""
+    return _normalize_template(
+        topic_template,
+        default=_DEFAULT_PACKET_TOPIC_TEMPLATE,
+        fields=_TOPIC_TEMPLATE_FIELD_CANONICAL,
+        label="packet",
+    )
 
 
 def _normalize_neighbor_topic_template(topic_template: str) -> str:
     """Normalize neighbor topic fields, including the ``{TYPE}`` suffix hook."""
-    template = topic_template.strip() or _DEFAULT_NEIGHBOR_TOPIC_TEMPLATE
-    parts: list[str] = []
-    try:
-        parsed = string.Formatter().parse(template)
-        for literal_text, field_name, format_spec, conversion in parsed:
-            parts.append(literal_text)
-            if field_name is None:
-                continue
-            normalized_field = _NEIGHBOR_TOPIC_TEMPLATE_FIELD_CANONICAL.get(field_name.lower())
-            if normalized_field is None:
-                raise ValueError(f"Unsupported neighbor topic template field(s): {field_name}")
-            replacement = ["{", normalized_field]
-            if conversion:
-                replacement.extend(["!", conversion])
-            if format_spec:
-                replacement.extend([":", format_spec])
-            replacement.append("}")
-            parts.append("".join(replacement))
-    except ValueError:
-        raise
-
-    normalized = "".join(parts)
-    if not (normalized.endswith("/neighbors") or normalized.endswith("/{TYPE}")):
-        raise ValueError("Neighbor topic templates must end with /neighbors or /{TYPE}")
-    return normalized
+    return _normalize_template(
+        topic_template,
+        default=_DEFAULT_NEIGHBOR_TOPIC_TEMPLATE,
+        fields=_NEIGHBOR_TOPIC_TEMPLATE_FIELD_CANONICAL,
+        label="neighbor",
+        required_suffixes=("/neighbors", "/{TYPE}"),
+    )
 
 
 def _config_to_settings(config: dict) -> SimpleNamespace:
@@ -139,9 +140,6 @@ class MqttCommunityModule(FanoutModule):
         pass
 
     async def on_raw(self, data: dict) -> None:
-        # Neighbor cache observations are radio facts, not MQTT delivery
-        # attempts.  Keep recording them while this broker reconnects.
-        await community_neighbor_reporter.observe_raw_packet(data)
         if not self._publisher.connected or self._publisher._settings is None:
             return
         await _publish_community_packet(self._publisher, self.config, data)

--- a/app/fanout/mqtt_community.py
+++ b/app/fanout/mqtt_community.py
@@ -10,14 +10,24 @@ from typing import Any
 
 from app.fanout.base import FanoutModule
 from app.fanout.community_mqtt import CommunityMqttPublisher, _format_raw_packet
+from app.fanout.community_neighbors import community_neighbor_reporter
 
 logger = logging.getLogger(__name__)
 
 _IATA_RE = re.compile(r"^[A-Z]{3}$")
 _DEFAULT_PACKET_TOPIC_TEMPLATE = "meshcore/{IATA}/{PUBLIC_KEY}/packets"
+_DEFAULT_NEIGHBOR_TOPIC_TEMPLATE = "meshcore/{IATA}/{PUBLIC_KEY}/neighbors"
 _TOPIC_TEMPLATE_FIELD_CANONICAL = {
     "iata": "IATA",
     "public_key": "PUBLIC_KEY",
+}
+_NEIGHBOR_TOPIC_TEMPLATE_FIELD_CANONICAL = {
+    **_TOPIC_TEMPLATE_FIELD_CANONICAL,
+    # ``device`` and ``type`` are the common names used by generic community
+    # MQTT template systems.  Keep PUBLIC_KEY as the established RemoteTerm
+    # spelling and make both forms render the same observer identity.
+    "device": "PUBLIC_KEY",
+    "type": "TYPE",
 }
 
 
@@ -47,6 +57,35 @@ def _normalize_topic_template(topic_template: str) -> str:
     return "".join(parts)
 
 
+def _normalize_neighbor_topic_template(topic_template: str) -> str:
+    """Normalize neighbor topic fields, including the ``{TYPE}`` suffix hook."""
+    template = topic_template.strip() or _DEFAULT_NEIGHBOR_TOPIC_TEMPLATE
+    parts: list[str] = []
+    try:
+        parsed = string.Formatter().parse(template)
+        for literal_text, field_name, format_spec, conversion in parsed:
+            parts.append(literal_text)
+            if field_name is None:
+                continue
+            normalized_field = _NEIGHBOR_TOPIC_TEMPLATE_FIELD_CANONICAL.get(field_name.lower())
+            if normalized_field is None:
+                raise ValueError(f"Unsupported neighbor topic template field(s): {field_name}")
+            replacement = ["{", normalized_field]
+            if conversion:
+                replacement.extend(["!", conversion])
+            if format_spec:
+                replacement.extend([":", format_spec])
+            replacement.append("}")
+            parts.append("".join(replacement))
+    except ValueError:
+        raise
+
+    normalized = "".join(parts)
+    if not (normalized.endswith("/neighbors") or normalized.endswith("/{TYPE}")):
+        raise ValueError("Neighbor topic templates must end with /neighbors or /{TYPE}")
+    return normalized
+
+
 def _config_to_settings(config: dict) -> SimpleNamespace:
     """Map a fanout config blob to a settings namespace for the CommunityMqttPublisher."""
     return SimpleNamespace(
@@ -72,6 +111,12 @@ def _render_packet_topic(topic_template: str, *, iata: str, public_key: str) -> 
     return template.format(IATA=iata, PUBLIC_KEY=public_key)
 
 
+def _render_neighbor_topic(topic_template: str, *, iata: str, public_key: str) -> str:
+    """Render the configured MQTT topic for one canonical neighbor snapshot."""
+    template = _normalize_neighbor_topic_template(topic_template)
+    return template.format(IATA=iata, PUBLIC_KEY=public_key, TYPE="neighbors")
+
+
 class MqttCommunityModule(FanoutModule):
     """Wraps a CommunityMqttPublisher for community packet sharing."""
 
@@ -83,8 +128,10 @@ class MqttCommunityModule(FanoutModule):
     async def start(self) -> None:
         settings = _config_to_settings(self.config)
         await self._publisher.start(settings)
+        await community_neighbor_reporter.register_module(self)
 
     async def stop(self) -> None:
+        await community_neighbor_reporter.unregister_module(self.config_id)
         await self._publisher.stop()
 
     async def on_message(self, data: dict) -> None:
@@ -92,9 +139,51 @@ class MqttCommunityModule(FanoutModule):
         pass
 
     async def on_raw(self, data: dict) -> None:
+        # Neighbor cache observations are radio facts, not MQTT delivery
+        # attempts.  Keep recording them while this broker reconnects.
+        await community_neighbor_reporter.observe_raw_packet(data)
         if not self._publisher.connected or self._publisher._settings is None:
             return
         await _publish_community_packet(self._publisher, self.config, data)
+
+    @property
+    def neighbor_publisher_connected(self) -> bool:
+        """Whether this slot can accept a completed neighbor snapshot now."""
+        return self._publisher.connected and self._publisher._settings is not None
+
+    async def publish_neighbor_snapshot(self, serialized_snapshot: str) -> bool:
+        """Publish an already-frozen canonical neighbor JSON document at QoS 1."""
+        if not self.neighbor_publisher_connected:
+            return False
+
+        try:
+            from app.keystore import get_public_key
+
+            public_key = get_public_key()
+            if public_key is None or len(public_key) != 32:
+                return False
+
+            iata = str(self.config.get("iata", "")).upper().strip()
+            if not _IATA_RE.fullmatch(iata):
+                logger.debug(
+                    "Community MQTT: skipping neighbor snapshot — no valid IATA code configured"
+                )
+                return False
+
+            topic = _render_neighbor_topic(
+                str(self.config.get("neighbor_topic_template", _DEFAULT_NEIGHBOR_TOPIC_TEMPLATE)),
+                iata=iata,
+                public_key=public_key.hex().upper(),
+            )
+            return await self._publisher.publish(
+                topic,
+                serialized_snapshot,
+                retain=bool(self.config.get("neighbor_retain", False)),
+                qos=1,
+            )
+        except Exception:
+            logger.warning("Community MQTT neighbor snapshot publish error", exc_info=True)
+            return False
 
     @property
     def status(self) -> str:

--- a/app/packet_processor.py
+++ b/app/packet_processor.py
@@ -346,11 +346,9 @@ async def process_raw_packet(
         "sender": None,
     }
 
-    # Community MQTT neighbor reporting has a small temporary decryption
-    # overlay for anonymous region responses.  Feed its radio observations
-    # directly from the primary RX pipeline instead of waiting for the
-    # asynchronous fanout dispatch; this preserves very fast zero-hop replies
-    # and records passive adverts even while an MQTT client reconnects.
+    # Feed neighbor radio observations directly from the primary RX pipeline.
+    # Scope responses must be matched before asynchronous fanout dispatch, and
+    # passive adverts must remain observable while MQTT clients reconnect.
     if payload_type in (PayloadType.ADVERT, PayloadType.RESPONSE):
         try:
             from app.fanout.community_neighbors import community_neighbor_reporter
@@ -359,7 +357,6 @@ async def process_raw_packet(
                 raw_bytes,
                 timestamp=ts,
                 measured_snr=snr,
-                observation_id=observation_id,
             )
         except Exception:
             logger.debug("Community neighbor raw observation failed", exc_info=True)

--- a/app/packet_processor.py
+++ b/app/packet_processor.py
@@ -346,6 +346,24 @@ async def process_raw_packet(
         "sender": None,
     }
 
+    # Community MQTT neighbor reporting has a small temporary decryption
+    # overlay for anonymous region responses.  Feed its radio observations
+    # directly from the primary RX pipeline instead of waiting for the
+    # asynchronous fanout dispatch; this preserves very fast zero-hop replies
+    # and records passive adverts even while an MQTT client reconnects.
+    if payload_type in (PayloadType.ADVERT, PayloadType.RESPONSE):
+        try:
+            from app.fanout.community_neighbors import community_neighbor_reporter
+
+            await community_neighbor_reporter.observe_packet(
+                raw_bytes,
+                timestamp=ts,
+                measured_snr=snr,
+                observation_id=observation_id,
+            )
+        except Exception:
+            logger.debug("Community neighbor raw observation failed", exc_info=True)
+
     # Compute packet hash once for threading into message broadcasts (used by bot fanout).
     pkt_hash = calculate_packet_hash(raw_bytes)
 

--- a/app/routers/fanout.py
+++ b/app/routers/fanout.py
@@ -29,6 +29,7 @@ _VALID_TYPES = {
 
 _IATA_RE = re.compile(r"^[A-Z]{3}$")
 _DEFAULT_COMMUNITY_MQTT_TOPIC_TEMPLATE = "meshcore/{IATA}/{PUBLIC_KEY}/packets"
+_DEFAULT_COMMUNITY_NEIGHBOR_TOPIC_TEMPLATE = "meshcore/{IATA}/{PUBLIC_KEY}/neighbors"
 _DEFAULT_COMMUNITY_MQTT_BROKER_HOST = "mqtt-us-v1.letsmesh.net"
 _DEFAULT_COMMUNITY_MQTT_BROKER_PORT = 443
 _DEFAULT_COMMUNITY_MQTT_TRANSPORT = "websockets"
@@ -36,6 +37,11 @@ _DEFAULT_COMMUNITY_MQTT_AUTH_MODE = "token"
 _COMMUNITY_MQTT_TEMPLATE_FIELD_CANONICAL = {
     "iata": "IATA",
     "public_key": "PUBLIC_KEY",
+}
+_COMMUNITY_NEIGHBOR_TEMPLATE_FIELD_CANONICAL = {
+    **_COMMUNITY_MQTT_TEMPLATE_FIELD_CANONICAL,
+    "device": "PUBLIC_KEY",
+    "type": "TYPE",
 }
 _ALLOWED_COMMUNITY_MQTT_TRANSPORTS = {"tcp", "websockets"}
 _ALLOWED_COMMUNITY_MQTT_AUTH_MODES = {"token", "password", "none"}
@@ -70,6 +76,47 @@ def _normalize_community_topic_template(topic_template: str) -> str:
         raise HTTPException(status_code=400, detail=f"Invalid topic_template: {exc}") from None
 
     return "".join(parts)
+
+
+def _normalize_community_neighbor_topic_template(topic_template: str) -> str:
+    """Normalize Community MQTT neighbor topic fields including ``{TYPE}``."""
+    template = topic_template.strip() or _DEFAULT_COMMUNITY_NEIGHBOR_TOPIC_TEMPLATE
+    parts: list[str] = []
+    try:
+        parsed = string.Formatter().parse(template)
+        for literal_text, field_name, format_spec, conversion in parsed:
+            parts.append(literal_text)
+            if field_name is None:
+                continue
+            normalized_field = _COMMUNITY_NEIGHBOR_TEMPLATE_FIELD_CANONICAL.get(field_name.lower())
+            if normalized_field is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "neighbor_topic_template may only use {IATA}, {PUBLIC_KEY}, "
+                        "{DEVICE}, and {TYPE}; got "
+                        f"{field_name}"
+                    ),
+                )
+            replacement = ["{", normalized_field]
+            if conversion:
+                replacement.extend(["!", conversion])
+            if format_spec:
+                replacement.extend([":", format_spec])
+            replacement.append("}")
+            parts.append("".join(replacement))
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid neighbor_topic_template: {exc}"
+        ) from None
+
+    normalized = "".join(parts)
+    if not (normalized.endswith("/neighbors") or normalized.endswith("/{TYPE}")):
+        raise HTTPException(
+            status_code=400,
+            detail="neighbor_topic_template must end with /neighbors or /{TYPE}",
+        )
+    return normalized
 
 
 class FanoutConfigCreate(BaseModel):
@@ -177,6 +224,56 @@ def _validate_mqtt_community_config(config: dict) -> None:
         topic_template = _DEFAULT_COMMUNITY_MQTT_TOPIC_TEMPLATE
 
     config["topic_template"] = _normalize_community_topic_template(topic_template)
+
+    # Neighbor reports share the same radio-side coordinator across every
+    # Community MQTT broker.  The configuration is stored per broker because
+    # topic/retain policy is slot-specific; the coordinator freezes one
+    # snapshot and publishes that exact document to all participating slots.
+    reporting_enabled = config.get("neighbor_reporting_enabled", False)
+    if not isinstance(reporting_enabled, bool):
+        raise HTTPException(status_code=400, detail="neighbor_reporting_enabled must be a boolean")
+    config["neighbor_reporting_enabled"] = reporting_enabled
+
+    interval_hours = config.get("neighbor_reporting_interval_hours", 24)
+    if isinstance(interval_hours, bool) or not isinstance(interval_hours, int):
+        raise HTTPException(
+            status_code=400,
+            detail="neighbor_reporting_interval_hours must be an integer between 12 and 336",
+        )
+    if not 12 <= interval_hours <= 336:
+        raise HTTPException(
+            status_code=400,
+            detail="neighbor_reporting_interval_hours must be between 12 and 336",
+        )
+    config["neighbor_reporting_interval_hours"] = interval_hours
+
+    origin = config.get("neighbor_origin", "")
+    if not isinstance(origin, str):
+        raise HTTPException(status_code=400, detail="neighbor_origin must be a string")
+    config["neighbor_origin"] = origin.strip()
+
+    try:
+        from app.fanout.community_neighbors import normalize_self_scopes
+
+        config["neighbor_self_scopes"] = normalize_self_scopes(
+            config.get("neighbor_self_scopes", "")
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+
+    neighbor_topic_template = config.get(
+        "neighbor_topic_template", _DEFAULT_COMMUNITY_NEIGHBOR_TOPIC_TEMPLATE
+    )
+    if not isinstance(neighbor_topic_template, str):
+        raise HTTPException(status_code=400, detail="neighbor_topic_template must be a string")
+    config["neighbor_topic_template"] = _normalize_community_neighbor_topic_template(
+        neighbor_topic_template
+    )
+
+    retain = config.get("neighbor_retain", False)
+    if not isinstance(retain, bool):
+        raise HTTPException(status_code=400, detail="neighbor_retain must be a boolean")
+    config["neighbor_retain"] = retain
 
 
 def _validate_bot_config(config: dict) -> None:
@@ -472,6 +569,73 @@ async def update_fanout_config(config_id: str, body: FanoutConfigUpdate) -> dict
 
     logger.info("Updated fanout config %s", config_id)
     return updated
+
+
+async def _require_community_neighbor_config(config_id: str) -> dict:
+    """Validate that a live config can use the shared Community MQTT reporter."""
+    existing = await FanoutConfigRepository.get(config_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Fanout config not found")
+    if existing["type"] != "mqtt_community":
+        raise HTTPException(
+            status_code=400, detail="Neighbor reporting requires a Community MQTT config"
+        )
+    if not existing["enabled"]:
+        raise HTTPException(status_code=409, detail="Community MQTT integration is disabled")
+    return existing
+
+
+@router.get("/{config_id}/community-neighbors/status")
+async def get_community_neighbor_status(config_id: str) -> dict:
+    """Return cache and shared-workflow state for a Community MQTT slot."""
+    await _require_community_neighbor_config(config_id)
+    from app.fanout.community_neighbors import community_neighbor_reporter
+
+    return community_neighbor_reporter.status_for(config_id)
+
+
+@router.post("/{config_id}/community-neighbors/discover")
+async def discover_community_neighbors(config_id: str) -> dict:
+    """Start or join a non-publishing 60-second zero-hop neighbor refresh."""
+    await _require_community_neighbor_config(config_id)
+    from app.fanout.community_neighbors import NeighborReporterError, community_neighbor_reporter
+
+    try:
+        return await community_neighbor_reporter.start_manual_discovery(config_id)
+    except NeighborReporterError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from None
+
+
+@router.post("/{config_id}/community-neighbors/snapshot")
+async def publish_community_neighbor_snapshot(config_id: str) -> dict:
+    """Query cached direct repeaters and publish one completion snapshot."""
+    await _require_community_neighbor_config(config_id)
+    from app.fanout.community_neighbors import NeighborReporterError, community_neighbor_reporter
+
+    try:
+        return await community_neighbor_reporter.start_manual_snapshot(config_id)
+    except NeighborReporterError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from None
+
+
+@router.delete("/{config_id}/community-neighbors/{public_key}")
+async def remove_community_neighbor(config_id: str, public_key: str) -> dict:
+    """Explicitly remove one cached direct repeater neighbour by public key."""
+    await _require_community_neighbor_config(config_id)
+    from app.fanout.community_neighbors import community_neighbor_reporter
+
+    removed = await community_neighbor_reporter.remove_neighbor(public_key)
+    return {"removed": removed, "public_key": public_key.lower()}
+
+
+@router.delete("/{config_id}/community-neighbors")
+async def clear_community_neighbors(config_id: str) -> dict:
+    """Remove all cached direct repeater neighbours."""
+    await _require_community_neighbor_config(config_id)
+    from app.fanout.community_neighbors import community_neighbor_reporter
+
+    count = await community_neighbor_reporter.clear_neighbors()
+    return {"cleared": count}
 
 
 @router.delete("/{config_id}")

--- a/app/routers/fanout.py
+++ b/app/routers/fanout.py
@@ -4,7 +4,6 @@ import ast
 import inspect
 import logging
 import re
-import string
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
@@ -34,89 +33,30 @@ _DEFAULT_COMMUNITY_MQTT_BROKER_HOST = "mqtt-us-v1.letsmesh.net"
 _DEFAULT_COMMUNITY_MQTT_BROKER_PORT = 443
 _DEFAULT_COMMUNITY_MQTT_TRANSPORT = "websockets"
 _DEFAULT_COMMUNITY_MQTT_AUTH_MODE = "token"
-_COMMUNITY_MQTT_TEMPLATE_FIELD_CANONICAL = {
-    "iata": "IATA",
-    "public_key": "PUBLIC_KEY",
-}
-_COMMUNITY_NEIGHBOR_TEMPLATE_FIELD_CANONICAL = {
-    **_COMMUNITY_MQTT_TEMPLATE_FIELD_CANONICAL,
-    "device": "PUBLIC_KEY",
-    "type": "TYPE",
-}
 _ALLOWED_COMMUNITY_MQTT_TRANSPORTS = {"tcp", "websockets"}
 _ALLOWED_COMMUNITY_MQTT_AUTH_MODES = {"token", "password", "none"}
 
 
 def _normalize_community_topic_template(topic_template: str) -> str:
-    """Normalize Community MQTT topic template placeholders to canonical uppercase form."""
-    template = topic_template.strip() or _DEFAULT_COMMUNITY_MQTT_TOPIC_TEMPLATE
-    parts: list[str] = []
+    """Validate packet topic templates through the runtime renderer contract."""
+    from app.fanout.mqtt_community import _normalize_topic_template
+
     try:
-        parsed = string.Formatter().parse(template)
-        for literal_text, field_name, format_spec, conversion in parsed:
-            parts.append(literal_text)
-            if field_name is None:
-                continue
-            normalized_field = _COMMUNITY_MQTT_TEMPLATE_FIELD_CANONICAL.get(field_name.lower())
-            if normalized_field is None:
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        f"topic_template may only use {{IATA}} and {{PUBLIC_KEY}}; got {field_name}"
-                    ),
-                )
-            replacement = ["{", normalized_field]
-            if conversion:
-                replacement.extend(["!", conversion])
-            if format_spec:
-                replacement.extend([":", format_spec])
-            replacement.append("}")
-            parts.append("".join(replacement))
+        return _normalize_topic_template(topic_template)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=f"Invalid topic_template: {exc}") from None
 
-    return "".join(parts)
-
 
 def _normalize_community_neighbor_topic_template(topic_template: str) -> str:
-    """Normalize Community MQTT neighbor topic fields including ``{TYPE}``."""
-    template = topic_template.strip() or _DEFAULT_COMMUNITY_NEIGHBOR_TOPIC_TEMPLATE
-    parts: list[str] = []
+    """Validate neighbor topic templates through the runtime renderer contract."""
+    from app.fanout.mqtt_community import _normalize_neighbor_topic_template
+
     try:
-        parsed = string.Formatter().parse(template)
-        for literal_text, field_name, format_spec, conversion in parsed:
-            parts.append(literal_text)
-            if field_name is None:
-                continue
-            normalized_field = _COMMUNITY_NEIGHBOR_TEMPLATE_FIELD_CANONICAL.get(field_name.lower())
-            if normalized_field is None:
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        "neighbor_topic_template may only use {IATA}, {PUBLIC_KEY}, "
-                        "{DEVICE}, and {TYPE}; got "
-                        f"{field_name}"
-                    ),
-                )
-            replacement = ["{", normalized_field]
-            if conversion:
-                replacement.extend(["!", conversion])
-            if format_spec:
-                replacement.extend([":", format_spec])
-            replacement.append("}")
-            parts.append("".join(replacement))
+        return _normalize_neighbor_topic_template(topic_template)
     except ValueError as exc:
         raise HTTPException(
             status_code=400, detail=f"Invalid neighbor_topic_template: {exc}"
         ) from None
-
-    normalized = "".join(parts)
-    if not (normalized.endswith("/neighbors") or normalized.endswith("/{TYPE}")):
-        raise HTTPException(
-            status_code=400,
-            detail="neighbor_topic_template must end with /neighbors or /{TYPE}",
-        )
-    return normalized
 
 
 class FanoutConfigCreate(BaseModel):
@@ -209,7 +149,10 @@ def _validate_mqtt_community_config(config: dict) -> None:
     token_audience = str(config.get("token_audience", "")).strip()
     config["token_audience"] = token_audience
 
-    iata = config.get("iata", "").upper().strip()
+    raw_iata = config.get("iata", "")
+    if not isinstance(raw_iata, str):
+        raise HTTPException(status_code=400, detail="IATA code must be a string")
+    iata = raw_iata.upper().strip()
     if not iata or not _IATA_RE.fullmatch(iata):
         raise HTTPException(
             status_code=400,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,6 +4,8 @@ import type {
   BulkCreateHashtagChannelsResult,
   Channel,
   ChannelDetail,
+  CommunityNeighborActionResponse,
+  CommunityNeighborStatus,
   CommandResponse,
   Contact,
   ContactAnalytics,
@@ -405,6 +407,16 @@ export const api = {
       bots_disabled: boolean;
       bots_disabled_source: 'env' | 'until_restart';
     }>('/fanout/bots/disable-until-restart', {
+      method: 'POST',
+    }),
+  getCommunityNeighborStatus: (id: string) =>
+    fetchJson<CommunityNeighborStatus>(`/fanout/${id}/community-neighbors/status`),
+  discoverCommunityNeighbors: (id: string) =>
+    fetchJson<CommunityNeighborActionResponse>(`/fanout/${id}/community-neighbors/discover`, {
+      method: 'POST',
+    }),
+  publishCommunityNeighborSnapshot: (id: string) =>
+    fetchJson<CommunityNeighborActionResponse>(`/fanout/${id}/community-neighbors/snapshot`, {
       method: 'POST',
     }),
 

--- a/frontend/src/components/settings/SettingsFanoutSection.tsx
+++ b/frontend/src/components/settings/SettingsFanoutSection.tsx
@@ -24,7 +24,13 @@ import {
 import { toast } from '../ui/sonner';
 import { cn } from '@/lib/utils';
 import { api } from '../../api';
-import type { Channel, Contact, FanoutConfig, HealthStatus } from '../../types';
+import type {
+  Channel,
+  CommunityNeighborStatus,
+  Contact,
+  FanoutConfig,
+  HealthStatus,
+} from '../../types';
 
 const BotCodeEditor = lazy(() =>
   import('../BotCodeEditor').then((m) => ({ default: m.BotCodeEditor }))
@@ -42,6 +48,10 @@ const TYPE_LABELS: Record<string, string> = {
 };
 
 const DEFAULT_COMMUNITY_PACKET_TOPIC_TEMPLATE = 'meshcore/{IATA}/{PUBLIC_KEY}/packets';
+const DEFAULT_COMMUNITY_NEIGHBOR_TOPIC_TEMPLATE = 'meshcore/{IATA}/{PUBLIC_KEY}/neighbors';
+const DEFAULT_COMMUNITY_NEIGHBOR_REPORTING_INTERVAL_HOURS = 24;
+const MIN_COMMUNITY_NEIGHBOR_REPORTING_INTERVAL_HOURS = 12;
+const MAX_COMMUNITY_NEIGHBOR_REPORTING_INTERVAL_HOURS = 336;
 const DEFAULT_COMMUNITY_BROKER_HOST = 'mqtt-us-v1.letsmesh.net';
 const DEFAULT_COMMUNITY_BROKER_HOST_EU = 'mqtt-eu-v1.letsmesh.net';
 const DEFAULT_COMMUNITY_BROKER_PORT = 443;
@@ -69,6 +79,12 @@ function createCommunityConfigDefaults(
     email: '',
     token_audience: '',
     topic_template: DEFAULT_COMMUNITY_PACKET_TOPIC_TEMPLATE,
+    neighbor_reporting_enabled: false,
+    neighbor_reporting_interval_hours: DEFAULT_COMMUNITY_NEIGHBOR_REPORTING_INTERVAL_HOURS,
+    neighbor_origin: '',
+    neighbor_self_scopes: '',
+    neighbor_topic_template: DEFAULT_COMMUNITY_NEIGHBOR_TOPIC_TEMPLATE,
+    neighbor_retain: false,
     ...overrides,
   };
 }
@@ -140,6 +156,13 @@ type DraftType =
   | 'sqs'
   | 'bot'
   | 'map_upload';
+
+type CommunityNeighborAction = 'discover' | 'snapshot';
+
+type CommunityNeighborFeedback = {
+  message: string;
+  isError: boolean;
+};
 
 type CreateIntegrationDefinition = {
   value: DraftType;
@@ -433,6 +456,30 @@ function normalizeIntegrationConfigForSave(
 
     const topicTemplate = String(normalized.topic_template ?? '').trim();
     normalized.topic_template = topicTemplate || DEFAULT_COMMUNITY_PACKET_TOPIC_TEMPLATE;
+
+    normalized.neighbor_reporting_enabled = Boolean(normalized.neighbor_reporting_enabled);
+    const neighborInterval = Number.parseInt(
+      String(
+        normalized.neighbor_reporting_interval_hours ??
+          DEFAULT_COMMUNITY_NEIGHBOR_REPORTING_INTERVAL_HOURS
+      ),
+      10
+    );
+    normalized.neighbor_reporting_interval_hours = Math.min(
+      MAX_COMMUNITY_NEIGHBOR_REPORTING_INTERVAL_HOURS,
+      Math.max(
+        MIN_COMMUNITY_NEIGHBOR_REPORTING_INTERVAL_HOURS,
+        Number.isNaN(neighborInterval)
+          ? DEFAULT_COMMUNITY_NEIGHBOR_REPORTING_INTERVAL_HOURS
+          : neighborInterval
+      )
+    );
+    normalized.neighbor_origin = String(normalized.neighbor_origin ?? '').trim();
+    normalized.neighbor_self_scopes = String(normalized.neighbor_self_scopes ?? '').trim();
+    const neighborTopicTemplate = String(normalized.neighbor_topic_template ?? '').trim();
+    normalized.neighbor_topic_template =
+      neighborTopicTemplate || DEFAULT_COMMUNITY_NEIGHBOR_TOPIC_TEMPLATE;
+    normalized.neighbor_retain = Boolean(normalized.neighbor_retain);
   }
 
   if (configType === 'map_upload') {
@@ -727,6 +774,23 @@ function getDefaultIntegrationName(type: string, configs: FanoutConfig[]) {
   const label = TYPE_LABELS[type] || type;
   const nextIndex = configs.filter((cfg) => cfg.type === type).length + 1;
   return `${label} #${nextIndex}`;
+}
+
+function getCommunityNeighborPhaseLabel(phase: CommunityNeighborStatus['phase']) {
+  switch (phase) {
+    case 'refresh':
+      return 'refreshing direct neighbors';
+    case 'scopes':
+      return 'querying scopes';
+    case 'publishing':
+      return 'publishing snapshot';
+    case 'scheduled':
+      return 'waiting for the next report';
+    case 'due':
+      return 'waiting for a connected broker';
+    case 'idle':
+      return 'idle';
+  }
 }
 
 function getStatusLabel(status: string | undefined, type?: string) {
@@ -1703,6 +1767,107 @@ function MqttCommunityConfigEditor({
           Use <code>{'{IATA}'}</code> and <code>{'{PUBLIC_KEY}'}</code>. Default:{' '}
           <code>{DEFAULT_COMMUNITY_PACKET_TOPIC_TEMPLATE}</code>
         </p>
+      </div>
+
+      <Separator />
+
+      <div className="space-y-3">
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold tracking-tight">Neighbor Reporting</h3>
+          <p className="text-[0.8125rem] text-muted-foreground">
+            Publish directly heard repeater identities and their flood-allowed scopes to a separate
+            MQTT snapshot. Manual snapshots remain available from the integration card.
+          </p>
+        </div>
+
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            id="fanout-comm-neighbor-reporting-enabled"
+            type="checkbox"
+            checked={config.neighbor_reporting_enabled === true}
+            onChange={(e) => onChange({ ...config, neighbor_reporting_enabled: e.target.checked })}
+            className="h-4 w-4 rounded border-border"
+          />
+          <span className="text-sm">Enable periodic neighbor reports</span>
+        </label>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="fanout-comm-neighbor-interval">Report Interval (hours)</Label>
+            <Input
+              id="fanout-comm-neighbor-interval"
+              type="number"
+              min={MIN_COMMUNITY_NEIGHBOR_REPORTING_INTERVAL_HOURS}
+              max={MAX_COMMUNITY_NEIGHBOR_REPORTING_INTERVAL_HOURS}
+              step="1"
+              value={getNumberInputValue(
+                config.neighbor_reporting_interval_hours,
+                DEFAULT_COMMUNITY_NEIGHBOR_REPORTING_INTERVAL_HOURS
+              )}
+              onChange={(e) =>
+                onChange({
+                  ...config,
+                  neighbor_reporting_interval_hours: parseIntegerInputValue(e.target.value),
+                })
+              }
+            />
+            <p className="text-[0.8125rem] text-muted-foreground">12–336 hours; default 24.</p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="fanout-comm-neighbor-origin">Origin (optional)</Label>
+            <Input
+              id="fanout-comm-neighbor-origin"
+              type="text"
+              placeholder="Observer label"
+              value={(config.neighbor_origin as string | undefined) ?? ''}
+              onChange={(e) => onChange({ ...config, neighbor_origin: e.target.value })}
+            />
+            <p className="text-[0.8125rem] text-muted-foreground">
+              Included as the observer origin in each neighbor snapshot.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="fanout-comm-neighbor-self-scopes">Observer Scopes</Label>
+          <Input
+            id="fanout-comm-neighbor-self-scopes"
+            type="text"
+            placeholder="*, Europe"
+            value={(config.neighbor_self_scopes as string | undefined) ?? ''}
+            onChange={(e) => onChange({ ...config, neighbor_self_scopes: e.target.value })}
+          />
+          <p className="text-[0.8125rem] text-muted-foreground">
+            Comma-separated flood-allowed scopes announced for this observer.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="fanout-comm-neighbor-topic-template">Neighbor Topic Template</Label>
+          <Input
+            id="fanout-comm-neighbor-topic-template"
+            type="text"
+            placeholder={DEFAULT_COMMUNITY_NEIGHBOR_TOPIC_TEMPLATE}
+            value={(config.neighbor_topic_template as string | undefined) ?? ''}
+            onChange={(e) => onChange({ ...config, neighbor_topic_template: e.target.value })}
+          />
+          <p className="text-[0.8125rem] text-muted-foreground">
+            Use <code>{'{IATA}'}</code>, <code>{'{PUBLIC_KEY}'}</code>, or <code>{'{TYPE}'}</code>{' '}
+            (renders <code>neighbors</code>). Default:{' '}
+            <code>{DEFAULT_COMMUNITY_NEIGHBOR_TOPIC_TEMPLATE}</code>
+          </p>
+        </div>
+
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            id="fanout-comm-neighbor-retain"
+            type="checkbox"
+            checked={config.neighbor_retain === true}
+            onChange={(e) => onChange({ ...config, neighbor_retain: e.target.checked })}
+            className="h-4 w-4 rounded border-border"
+          />
+          <span className="text-sm">Retain published neighbor snapshots</span>
+        </label>
       </div>
     </div>
   );
@@ -3029,11 +3194,40 @@ export function SettingsFanoutSection({
     error: string;
   } | null>(null);
   const [busy, setBusy] = useState(false);
+  const [communityNeighborStatuses, setCommunityNeighborStatuses] = useState<
+    Record<string, CommunityNeighborStatus>
+  >({});
+  const [communityNeighborAction, setCommunityNeighborAction] = useState<{
+    configId: string;
+    action: CommunityNeighborAction;
+  } | null>(null);
+  const [communityNeighborFeedback, setCommunityNeighborFeedback] = useState<
+    Record<string, CommunityNeighborFeedback>
+  >({});
+
+  const refreshCommunityNeighborStatus = useCallback(async (configId: string) => {
+    const status = await api.getCommunityNeighborStatus(configId);
+    setCommunityNeighborStatuses((current) => ({ ...current, [configId]: status }));
+    return status;
+  }, []);
 
   const loadConfigs = useCallback(async () => {
     try {
       const data = await api.getFanoutConfigs();
       setConfigs(data);
+      const statuses: Record<string, CommunityNeighborStatus> = {};
+      await Promise.all(
+        data
+          .filter((config) => config.type === 'mqtt_community' && config.enabled)
+          .map(async (config) => {
+            try {
+              statuses[config.id] = await api.getCommunityNeighborStatus(config.id);
+            } catch {
+              // An enabled integration may still be starting or unavailable.
+            }
+          })
+      );
+      setCommunityNeighborStatuses(statuses);
     } catch (err) {
       console.error('Failed to load fanout configs:', err);
     }
@@ -3074,6 +3268,47 @@ export function SettingsFanoutSection({
       toast.success(cfg.enabled ? 'Integration disabled' : 'Integration enabled');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to update');
+    }
+  };
+
+  const handleCommunityNeighborAction = async (
+    config: FanoutConfig,
+    action: CommunityNeighborAction
+  ) => {
+    setCommunityNeighborAction({ configId: config.id, action });
+    setCommunityNeighborFeedback((current) => {
+      const { [config.id]: _, ...rest } = current;
+      return rest;
+    });
+    try {
+      const result =
+        action === 'discover'
+          ? await api.discoverCommunityNeighbors(config.id)
+          : await api.publishCommunityNeighborSnapshot(config.id);
+      const fallbackMessage =
+        action === 'discover' ? 'Neighbor refresh started' : 'Neighbor snapshot started';
+      const message = result.message || fallbackMessage;
+      setCommunityNeighborFeedback((current) => ({
+        ...current,
+        [config.id]: { message, isError: false },
+      }));
+      toast.success(message);
+      try {
+        await refreshCommunityNeighborStatus(config.id);
+      } catch {
+        // The action was accepted even if its optional status refresh is unavailable.
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to start neighbor reporting';
+      setCommunityNeighborFeedback((current) => ({
+        ...current,
+        [config.id]: { message, isError: true },
+      }));
+      toast.error(message);
+    } finally {
+      setCommunityNeighborAction((current) =>
+        current?.configId === config.id && current.action === action ? null : current
+      );
     }
   };
 
@@ -3433,6 +3668,12 @@ export function SettingsFanoutSection({
                   const status = cfg.enabled ? statusEntry?.status : undefined;
                   const lastError = cfg.enabled ? statusEntry?.last_error : null;
                   const communityConfig = cfg.config as Record<string, unknown>;
+                  const neighborStatus = communityNeighborStatuses[cfg.id];
+                  const neighborActionForConfig =
+                    communityNeighborAction?.configId === cfg.id
+                      ? communityNeighborAction.action
+                      : null;
+                  const neighborFeedback = communityNeighborFeedback[cfg.id];
                   return (
                     <div
                       key={cfg.id}
@@ -3529,7 +3770,7 @@ export function SettingsFanoutSection({
                       </div>
 
                       {cfg.type === 'mqtt_community' && (
-                        <div className="space-y-1 border-t border-input px-3 py-2 text-xs text-muted-foreground">
+                        <div className="space-y-2 border-t border-input px-3 py-2 text-xs text-muted-foreground">
                           <div>
                             Broker:{' '}
                             {formatBrokerSummary(communityConfig, {
@@ -3544,6 +3785,72 @@ export function SettingsFanoutSection({
                                 DEFAULT_COMMUNITY_PACKET_TOPIC_TEMPLATE}
                             </code>
                           </div>
+                          <div>
+                            Neighbor reports:{' '}
+                            {neighborStatus ? (
+                              <>
+                                {getCommunityNeighborPhaseLabel(neighborStatus.phase)} ·{' '}
+                                {neighborStatus.cache_size} cached
+                                {neighborStatus.remaining_seconds !== null &&
+                                  ` · ${neighborStatus.remaining_seconds}s remaining`}
+                                {neighborStatus.last_publish_result &&
+                                  ` · last publish ${neighborStatus.last_publish_result}`}
+                              </>
+                            ) : communityConfig.neighbor_reporting_enabled === true ? (
+                              'enabled'
+                            ) : (
+                              'disabled'
+                            )}
+                          </div>
+                          <div className="flex flex-wrap gap-2 pt-0.5">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              className="h-7 px-2 text-xs"
+                              disabled={!cfg.enabled || neighborActionForConfig !== null}
+                              onClick={() => handleCommunityNeighborAction(cfg, 'discover')}
+                              title={
+                                cfg.enabled
+                                  ? 'Run a zero-hop repeater discovery refresh'
+                                  : 'Enable this integration to run neighbor discovery'
+                              }
+                            >
+                              {neighborActionForConfig === 'discover'
+                                ? 'Refreshing…'
+                                : 'Refresh neighbors'}
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              className="h-7 px-2 text-xs"
+                              disabled={!cfg.enabled || neighborActionForConfig !== null}
+                              onClick={() => handleCommunityNeighborAction(cfg, 'snapshot')}
+                              title={
+                                cfg.enabled
+                                  ? 'Publish a neighbor scope snapshot'
+                                  : 'Enable this integration to publish a neighbor snapshot'
+                              }
+                            >
+                              {neighborActionForConfig === 'snapshot'
+                                ? 'Publishing…'
+                                : 'Publish snapshot'}
+                            </Button>
+                          </div>
+                          {neighborFeedback && (
+                            <p
+                              role="status"
+                              className={cn(
+                                'text-[0.6875rem]',
+                                neighborFeedback.isError
+                                  ? 'text-destructive'
+                                  : 'text-status-connected'
+                              )}
+                            >
+                              {neighborFeedback.message}
+                            </p>
+                          )}
                         </div>
                       )}
 

--- a/frontend/src/components/settings/SettingsFanoutSection.tsx
+++ b/frontend/src/components/settings/SettingsFanoutSection.tsx
@@ -81,8 +81,6 @@ function createCommunityConfigDefaults(
     topic_template: DEFAULT_COMMUNITY_PACKET_TOPIC_TEMPLATE,
     neighbor_reporting_enabled: false,
     neighbor_reporting_interval_hours: DEFAULT_COMMUNITY_NEIGHBOR_REPORTING_INTERVAL_HOURS,
-    neighbor_origin: '',
-    neighbor_self_scopes: '',
     neighbor_topic_template: DEFAULT_COMMUNITY_NEIGHBOR_TOPIC_TEMPLATE,
     neighbor_retain: false,
     ...overrides,
@@ -474,8 +472,6 @@ function normalizeIntegrationConfigForSave(
           : neighborInterval
       )
     );
-    normalized.neighbor_origin = String(normalized.neighbor_origin ?? '').trim();
-    normalized.neighbor_self_scopes = String(normalized.neighbor_self_scopes ?? '').trim();
     const neighborTopicTemplate = String(normalized.neighbor_topic_template ?? '').trim();
     normalized.neighbor_topic_template =
       neighborTopicTemplate || DEFAULT_COMMUNITY_NEIGHBOR_TOPIC_TEMPLATE;
@@ -1813,33 +1809,6 @@ function MqttCommunityConfigEditor({
             />
             <p className="text-[0.8125rem] text-muted-foreground">12–336 hours; default 24.</p>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="fanout-comm-neighbor-origin">Origin (optional)</Label>
-            <Input
-              id="fanout-comm-neighbor-origin"
-              type="text"
-              placeholder="Observer label"
-              value={(config.neighbor_origin as string | undefined) ?? ''}
-              onChange={(e) => onChange({ ...config, neighbor_origin: e.target.value })}
-            />
-            <p className="text-[0.8125rem] text-muted-foreground">
-              Included as the observer origin in each neighbor snapshot.
-            </p>
-          </div>
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="fanout-comm-neighbor-self-scopes">Observer Scopes</Label>
-          <Input
-            id="fanout-comm-neighbor-self-scopes"
-            type="text"
-            placeholder="*, Europe"
-            value={(config.neighbor_self_scopes as string | undefined) ?? ''}
-            onChange={(e) => onChange({ ...config, neighbor_self_scopes: e.target.value })}
-          />
-          <p className="text-[0.8125rem] text-muted-foreground">
-            Comma-separated flood-allowed scopes announced for this observer.
-          </p>
         </div>
 
         <div className="space-y-2">

--- a/frontend/src/components/settings/SettingsFanoutSection.tsx
+++ b/frontend/src/components/settings/SettingsFanoutSection.tsx
@@ -81,6 +81,8 @@ function createCommunityConfigDefaults(
     topic_template: DEFAULT_COMMUNITY_PACKET_TOPIC_TEMPLATE,
     neighbor_reporting_enabled: false,
     neighbor_reporting_interval_hours: DEFAULT_COMMUNITY_NEIGHBOR_REPORTING_INTERVAL_HOURS,
+    neighbor_origin: '',
+    neighbor_self_scopes: '',
     neighbor_topic_template: DEFAULT_COMMUNITY_NEIGHBOR_TOPIC_TEMPLATE,
     neighbor_retain: false,
     ...overrides,
@@ -472,6 +474,8 @@ function normalizeIntegrationConfigForSave(
           : neighborInterval
       )
     );
+    normalized.neighbor_origin = String(normalized.neighbor_origin ?? '').trim();
+    normalized.neighbor_self_scopes = String(normalized.neighbor_self_scopes ?? '').trim();
     const neighborTopicTemplate = String(normalized.neighbor_topic_template ?? '').trim();
     normalized.neighbor_topic_template =
       neighborTopicTemplate || DEFAULT_COMMUNITY_NEIGHBOR_TOPIC_TEMPLATE;
@@ -1809,6 +1813,33 @@ function MqttCommunityConfigEditor({
             />
             <p className="text-[0.8125rem] text-muted-foreground">12–336 hours; default 24.</p>
           </div>
+          <div className="space-y-2">
+            <Label htmlFor="fanout-comm-neighbor-origin">Origin (optional)</Label>
+            <Input
+              id="fanout-comm-neighbor-origin"
+              type="text"
+              placeholder="Observer label"
+              value={(config.neighbor_origin as string | undefined) ?? ''}
+              onChange={(e) => onChange({ ...config, neighbor_origin: e.target.value })}
+            />
+            <p className="text-[0.8125rem] text-muted-foreground">
+              Included as the observer origin in each neighbor snapshot.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="fanout-comm-neighbor-self-scopes">Observer Scopes</Label>
+          <Input
+            id="fanout-comm-neighbor-self-scopes"
+            type="text"
+            placeholder="*, Europe"
+            value={(config.neighbor_self_scopes as string | undefined) ?? ''}
+            onChange={(e) => onChange({ ...config, neighbor_self_scopes: e.target.value })}
+          />
+          <p className="text-[0.8125rem] text-muted-foreground">
+            Comma-separated flood-allowed scopes announced for this observer.
+          </p>
         </div>
 
         <div className="space-y-2">

--- a/frontend/src/test/fanoutSection.test.tsx
+++ b/frontend/src/test/fanoutSection.test.tsx
@@ -784,8 +784,6 @@ describe('SettingsFanoutSection', () => {
 
     expect(screen.getByLabelText('Enable periodic neighbor reports')).not.toBeChecked();
     expect(screen.getByLabelText('Report Interval (hours)')).toHaveValue(24);
-    expect(screen.getByLabelText('Origin (optional)')).toHaveValue('');
-    expect(screen.getByLabelText('Observer Scopes')).toHaveValue('');
     expect(screen.getByLabelText('Neighbor Topic Template')).toHaveValue(
       'meshcore/{IATA}/{PUBLIC_KEY}/neighbors'
     );
@@ -975,8 +973,6 @@ describe('SettingsFanoutSection', () => {
           topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/packets',
           neighbor_reporting_enabled: false,
           neighbor_reporting_interval_hours: 24,
-          neighbor_origin: '',
-          neighbor_self_scopes: '',
           neighbor_topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/neighbors',
           neighbor_retain: false,
         },
@@ -1183,8 +1179,6 @@ describe('SettingsFanoutSection', () => {
           topic_template: 'meshrank/uplink/B435F6D5F7896B74C6B995FE221C2C1F/{PUBLIC_KEY}/packets',
           neighbor_reporting_enabled: false,
           neighbor_reporting_interval_hours: 24,
-          neighbor_origin: '',
-          neighbor_self_scopes: '',
           neighbor_topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/neighbors',
           neighbor_retain: false,
         },
@@ -1341,8 +1335,6 @@ describe('SettingsFanoutSection', () => {
           topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/packets',
           neighbor_reporting_enabled: false,
           neighbor_reporting_interval_hours: 24,
-          neighbor_origin: '',
-          neighbor_self_scopes: '',
           neighbor_topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/neighbors',
           neighbor_retain: false,
         },
@@ -1459,8 +1451,6 @@ describe('SettingsFanoutSection', () => {
           topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/packets',
           neighbor_reporting_enabled: false,
           neighbor_reporting_interval_hours: 24,
-          neighbor_origin: '',
-          neighbor_self_scopes: '',
           neighbor_topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/neighbors',
           neighbor_retain: false,
         },

--- a/frontend/src/test/fanoutSection.test.tsx
+++ b/frontend/src/test/fanoutSection.test.tsx
@@ -10,6 +10,9 @@ vi.mock('../api', () => ({
     createFanoutConfig: vi.fn(),
     updateFanoutConfig: vi.fn(),
     deleteFanoutConfig: vi.fn(),
+    getCommunityNeighborStatus: vi.fn(),
+    discoverCommunityNeighbors: vi.fn(),
+    publishCommunityNeighborSnapshot: vi.fn(),
     getChannels: vi.fn(),
     getContacts: vi.fn(),
     getSettings: vi.fn(),
@@ -96,6 +99,21 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.spyOn(window, 'confirm').mockReturnValue(true);
   mockedApi.getFanoutConfigs.mockResolvedValue([]);
+  mockedApi.getCommunityNeighborStatus.mockResolvedValue({
+    phase: 'idle',
+    cache_size: 0,
+    remaining_seconds: null,
+    periodic_enabled: false,
+    last_publish_result: null,
+  });
+  mockedApi.discoverCommunityNeighbors.mockResolvedValue({
+    status: 'started',
+    message: 'Neighbor refresh started',
+  });
+  mockedApi.publishCommunityNeighborSnapshot.mockResolvedValue({
+    status: 'started',
+    message: 'Neighbor snapshot started',
+  });
   mockedApi.getChannels.mockResolvedValue([]);
   mockedApi.getContacts.mockResolvedValue([]);
   mockedApi.getSettings.mockResolvedValue({
@@ -756,6 +774,76 @@ describe('SettingsFanoutSection', () => {
     expect(screen.getByText(/LetsMesh uses/)).toBeInTheDocument();
   });
 
+  it('community MQTT editor exposes neighbor reporting defaults', async () => {
+    renderSection();
+    await openCreateIntegrationDialog();
+    selectCreateIntegration('Community MQTT/meshcoretomqtt');
+    confirmCreateIntegration();
+
+    await waitFor(() => expect(screen.getByText('← Back to list')).toBeInTheDocument());
+
+    expect(screen.getByLabelText('Enable periodic neighbor reports')).not.toBeChecked();
+    expect(screen.getByLabelText('Report Interval (hours)')).toHaveValue(24);
+    expect(screen.getByLabelText('Origin (optional)')).toHaveValue('');
+    expect(screen.getByLabelText('Observer Scopes')).toHaveValue('');
+    expect(screen.getByLabelText('Neighbor Topic Template')).toHaveValue(
+      'meshcore/{IATA}/{PUBLIC_KEY}/neighbors'
+    );
+    expect(screen.getByLabelText('Retain published neighbor snapshots')).not.toBeChecked();
+  });
+
+  it('runs manual community neighbor actions and shows the accepted result', async () => {
+    const communityConfig: FanoutConfig = {
+      id: 'comm-neighbors',
+      type: 'mqtt_community',
+      name: 'Community Neighbors',
+      enabled: true,
+      config: {
+        broker_host: 'mqtt-us-v1.letsmesh.net',
+        broker_port: 443,
+        neighbor_reporting_enabled: true,
+      },
+      scope: { messages: 'none', raw_packets: 'all' },
+      sort_order: 0,
+      created_at: 1000,
+    };
+    mockedApi.getFanoutConfigs.mockResolvedValue([communityConfig]);
+    mockedApi.getCommunityNeighborStatus.mockResolvedValue({
+      phase: 'scheduled',
+      cache_size: 2,
+      remaining_seconds: 1800,
+      periodic_enabled: true,
+      last_publish_result: 'ok',
+    });
+    mockedApi.discoverCommunityNeighbors.mockResolvedValue({
+      status: 'started',
+      message: 'Collecting direct repeaters',
+    });
+    mockedApi.publishCommunityNeighborSnapshot.mockResolvedValue({
+      status: 'started',
+      message: 'Publishing neighbor snapshot',
+    });
+
+    renderSection();
+    const group = await screen.findByRole('group', { name: 'Integration Community Neighbors' });
+
+    expect(within(group).getByText(/Neighbor reports:/)).toHaveTextContent(
+      'waiting for the next report · 2 cached · 1800s remaining · last publish ok'
+    );
+
+    fireEvent.click(within(group).getByRole('button', { name: 'Refresh neighbors' }));
+    await waitFor(() =>
+      expect(mockedApi.discoverCommunityNeighbors).toHaveBeenCalledWith('comm-neighbors')
+    );
+    expect(within(group).getByRole('status')).toHaveTextContent('Collecting direct repeaters');
+
+    fireEvent.click(within(group).getByRole('button', { name: 'Publish snapshot' }));
+    await waitFor(() =>
+      expect(mockedApi.publishCommunityNeighborSnapshot).toHaveBeenCalledWith('comm-neighbors')
+    );
+    expect(within(group).getByRole('status')).toHaveTextContent('Publishing neighbor snapshot');
+  });
+
   it('existing community MQTT config without auth_mode defaults to token in the editor', async () => {
     const communityConfig: FanoutConfig = {
       id: 'comm-legacy',
@@ -885,6 +973,12 @@ describe('SettingsFanoutSection', () => {
           email: '',
           token_audience: '',
           topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/packets',
+          neighbor_reporting_enabled: false,
+          neighbor_reporting_interval_hours: 24,
+          neighbor_origin: '',
+          neighbor_self_scopes: '',
+          neighbor_topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/neighbors',
+          neighbor_retain: false,
         },
         scope: { messages: 'none', raw_packets: 'all' },
         enabled: true,
@@ -1087,6 +1181,12 @@ describe('SettingsFanoutSection', () => {
           email: '',
           token_audience: '',
           topic_template: 'meshrank/uplink/B435F6D5F7896B74C6B995FE221C2C1F/{PUBLIC_KEY}/packets',
+          neighbor_reporting_enabled: false,
+          neighbor_reporting_interval_hours: 24,
+          neighbor_origin: '',
+          neighbor_self_scopes: '',
+          neighbor_topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/neighbors',
+          neighbor_retain: false,
         },
         scope: { messages: 'none', raw_packets: 'all' },
         enabled: true,
@@ -1239,6 +1339,12 @@ describe('SettingsFanoutSection', () => {
           email: 'user@example.com',
           token_audience: 'mqtt-us-v1.letsmesh.net',
           topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/packets',
+          neighbor_reporting_enabled: false,
+          neighbor_reporting_interval_hours: 24,
+          neighbor_origin: '',
+          neighbor_self_scopes: '',
+          neighbor_topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/neighbors',
+          neighbor_retain: false,
         },
         scope: { messages: 'none', raw_packets: 'all' },
         enabled: false,
@@ -1351,6 +1457,12 @@ describe('SettingsFanoutSection', () => {
           email: 'user@example.com',
           token_audience: 'mqtt-eu-v1.letsmesh.net',
           topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/packets',
+          neighbor_reporting_enabled: false,
+          neighbor_reporting_interval_hours: 24,
+          neighbor_origin: '',
+          neighbor_self_scopes: '',
+          neighbor_topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/neighbors',
+          neighbor_retain: false,
         },
         scope: { messages: 'none', raw_packets: 'all' },
         enabled: true,

--- a/frontend/src/test/fanoutSection.test.tsx
+++ b/frontend/src/test/fanoutSection.test.tsx
@@ -784,6 +784,8 @@ describe('SettingsFanoutSection', () => {
 
     expect(screen.getByLabelText('Enable periodic neighbor reports')).not.toBeChecked();
     expect(screen.getByLabelText('Report Interval (hours)')).toHaveValue(24);
+    expect(screen.getByLabelText('Origin (optional)')).toHaveValue('');
+    expect(screen.getByLabelText('Observer Scopes')).toHaveValue('');
     expect(screen.getByLabelText('Neighbor Topic Template')).toHaveValue(
       'meshcore/{IATA}/{PUBLIC_KEY}/neighbors'
     );
@@ -973,6 +975,8 @@ describe('SettingsFanoutSection', () => {
           topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/packets',
           neighbor_reporting_enabled: false,
           neighbor_reporting_interval_hours: 24,
+          neighbor_origin: '',
+          neighbor_self_scopes: '',
           neighbor_topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/neighbors',
           neighbor_retain: false,
         },
@@ -1179,6 +1183,8 @@ describe('SettingsFanoutSection', () => {
           topic_template: 'meshrank/uplink/B435F6D5F7896B74C6B995FE221C2C1F/{PUBLIC_KEY}/packets',
           neighbor_reporting_enabled: false,
           neighbor_reporting_interval_hours: 24,
+          neighbor_origin: '',
+          neighbor_self_scopes: '',
           neighbor_topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/neighbors',
           neighbor_retain: false,
         },
@@ -1335,6 +1341,8 @@ describe('SettingsFanoutSection', () => {
           topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/packets',
           neighbor_reporting_enabled: false,
           neighbor_reporting_interval_hours: 24,
+          neighbor_origin: '',
+          neighbor_self_scopes: '',
           neighbor_topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/neighbors',
           neighbor_retain: false,
         },
@@ -1451,6 +1459,8 @@ describe('SettingsFanoutSection', () => {
           topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/packets',
           neighbor_reporting_enabled: false,
           neighbor_reporting_interval_hours: 24,
+          neighbor_origin: '',
+          neighbor_self_scopes: '',
           neighbor_topic_template: 'meshcore/{IATA}/{PUBLIC_KEY}/neighbors',
           neighbor_retain: false,
         },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -136,6 +136,28 @@ export interface FanoutConfig {
   created_at: number;
 }
 
+export type CommunityNeighborPhase =
+  | 'idle'
+  | 'refresh'
+  | 'scopes'
+  | 'publishing'
+  | 'scheduled'
+  | 'due';
+
+export interface CommunityNeighborStatus {
+  phase: CommunityNeighborPhase;
+  cache_size: number;
+  remaining_seconds: number | null;
+  periodic_enabled: boolean;
+  last_publish_result: 'ok' | 'failed' | null;
+}
+
+export interface CommunityNeighborActionResponse {
+  status: string;
+  message: string;
+  remaining_seconds?: number;
+}
+
 export interface MaintenanceResult {
   packets_deleted: number;
   vacuumed: boolean;

--- a/tests/test_community_neighbors.py
+++ b/tests/test_community_neighbors.py
@@ -1,0 +1,348 @@
+"""Focused contract tests for Community MQTT neighbor reporting."""
+
+from __future__ import annotations
+
+import hmac
+import json
+from hashlib import sha256
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from Crypto.Cipher import AES
+from fastapi import HTTPException
+
+from app.decoder import PayloadType, derive_public_key, derive_shared_secret
+from app.fanout.community_neighbors import (
+    CommunityNeighborReporter,
+    ScopeQueryEntry,
+    _format_snapshot_timestamp,
+    normalize_self_scopes,
+)
+from app.fanout.mqtt_community import (
+    _DEFAULT_NEIGHBOR_TOPIC_TEMPLATE as DEFAULT_NEIGHBOR_TOPIC,
+)
+from app.fanout.mqtt_community import (
+    MqttCommunityModule,
+    _render_neighbor_topic,
+)
+
+# These are fixed valid MeshCore-format Ed25519 key materials from the packet
+# pipeline tests.  They keep response-overlay encryption deterministic.
+OUR_PRIVATE_KEY = bytes.fromhex(
+    "58BA1940E97099CBB4357C62CE9C7F4B245C94C90D722E67201B989F9FEACF7B"
+    "77ACADDB84438514022BDB0FC3140C2501859BE1772AC7B8C7E41DC0F40490A1"
+)
+PEER_PUBLIC_KEY = bytes.fromhex("A1B2C3D3BA9F5FA8705B9845FE11CC6F01D1D49CAAF4D122AC7121663C5BEEC7")
+OUR_PUBLIC_KEY = derive_public_key(OUR_PRIVATE_KEY)
+
+
+class _Module:
+    def __init__(self, config_id: str, config: dict, *, connected: bool = True) -> None:
+        self.config_id = config_id
+        self.config = config
+        self.neighbor_publisher_connected = connected
+        self.published: list[str] = []
+
+    async def publish_neighbor_snapshot(self, serialized_snapshot: str) -> bool:
+        self.published.append(serialized_snapshot)
+        return True
+
+
+def _response_packet(*, tag: bytes, scopes: bytes) -> bytes:
+    """Build one authenticated direct PAYLOAD_TYPE_RESPONSE packet."""
+    plaintext = tag + (1_700_000_000).to_bytes(4, "little") + scopes
+    plaintext += bytes((-len(plaintext)) % 16)
+    secret = derive_shared_secret(OUR_PRIVATE_KEY, PEER_PUBLIC_KEY)
+    ciphertext = AES.new(secret[:16], AES.MODE_ECB).encrypt(plaintext)
+    mac = hmac.new(secret, ciphertext, sha256).digest()[:2]
+    payload = bytes((OUR_PUBLIC_KEY[0], PEER_PUBLIC_KEY[0])) + mac + ciphertext
+    # Header: direct route + response payload type, followed by zero hops.
+    return bytes(((int(PayloadType.RESPONSE) << 2) | 0x02, 0)) + payload
+
+
+class TestNeighborCache:
+    @pytest.mark.asyncio
+    async def test_passive_direct_signed_repeater_is_cached(self):
+        reporter = CommunityNeighborReporter()
+        peer = "11" * 32
+        envelope = SimpleNamespace(
+            payload_type=int(PayloadType.ADVERT),
+            hop_count=0,
+            transport_codes=None,
+            payload=b"advert",
+        )
+        advert = SimpleNamespace(public_key=peer, timestamp=123, device_role=2)
+
+        with (
+            patch("app.fanout.community_neighbors.parse_packet_envelope", return_value=envelope),
+            patch("app.fanout.community_neighbors.parse_advertisement", return_value=advert),
+            patch("app.fanout.community_neighbors.verify_advert_signature", return_value=True),
+            patch("app.keystore.get_public_key", return_value=None),
+        ):
+            await reporter.observe_packet(b"raw", timestamp=456, measured_snr=2.62)
+
+        cached = reporter._cache[peer]
+        assert cached.advert_timestamp == 123
+        assert cached.heard_timestamp == 456
+        assert cached.snr_q4 == 10
+
+    @pytest.mark.asyncio
+    async def test_share_advert_is_not_a_neighbor(self):
+        reporter = CommunityNeighborReporter()
+        envelope = SimpleNamespace(
+            payload_type=int(PayloadType.ADVERT),
+            hop_count=0,
+            transport_codes=(0, 0),
+            payload=b"advert",
+        )
+        with patch("app.fanout.community_neighbors.parse_packet_envelope", return_value=envelope):
+            await reporter.observe_packet(b"raw", timestamp=456, measured_snr=2.5)
+
+        assert reporter._cache == {}
+
+    @pytest.mark.asyncio
+    async def test_oldest_heard_entry_is_evicted_at_capacity(self):
+        reporter = CommunityNeighborReporter(cache_limit=2)
+        await reporter.put_neighbor(
+            "01" * 32, advert_timestamp=1, measured_snr=1, heard_timestamp=10
+        )
+        await reporter.put_neighbor(
+            "02" * 32, advert_timestamp=2, measured_snr=2, heard_timestamp=20
+        )
+        await reporter.put_neighbor(
+            "03" * 32, advert_timestamp=3, measured_snr=3, heard_timestamp=30
+        )
+
+        assert set(reporter._cache) == {"02" * 32, "03" * 32}
+
+
+class TestScopeResponseOverlay:
+    @pytest.mark.asyncio
+    async def test_authenticated_raw_response_completes_matching_non_contact_peer(self):
+        reporter = CommunityNeighborReporter()
+        tag = bytes.fromhex("A1B2C3D4")
+        entry = ScopeQueryEntry(
+            public_key=PEER_PUBLIC_KEY.hex(),
+            heard_timestamp=100,
+            snr_q4=8,
+            request_tag=tag.hex().lower(),
+        )
+        reporter._scope_active = True
+        reporter._scope_entries = [entry]
+        reporter._queries_by_tag[entry.request_tag] = entry
+
+        with (
+            patch("app.keystore.get_private_key", return_value=OUR_PRIVATE_KEY),
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+        ):
+            await reporter.observe_packet(_response_packet(tag=tag, scopes=b"*,Europe\0"))
+
+        assert entry.status == "responded"
+        assert entry.scopes == "*,Europe"
+
+    @pytest.mark.asyncio
+    async def test_wrong_tag_does_not_complete_overlay_entry(self):
+        reporter = CommunityNeighborReporter()
+        entry = ScopeQueryEntry(
+            public_key=PEER_PUBLIC_KEY.hex(),
+            heard_timestamp=100,
+            snr_q4=8,
+            request_tag="01020304",
+        )
+        reporter._scope_active = True
+        reporter._scope_entries = [entry]
+        reporter._queries_by_tag[entry.request_tag] = entry
+
+        with (
+            patch("app.keystore.get_private_key", return_value=OUR_PRIVATE_KEY),
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+        ):
+            await reporter.observe_packet(
+                _response_packet(tag=bytes.fromhex("05060708"), scopes=b"X")
+            )
+
+        assert entry.status == "pending"
+        assert entry.scopes == ""
+
+    @pytest.mark.asyncio
+    async def test_regions_command_uses_full_identity_and_zero_hop_reply_path(self):
+        reporter = CommunityNeighborReporter()
+        mc = MagicMock()
+        mc.commands.send = AsyncMock(return_value=SimpleNamespace())
+
+        await reporter._send_regions_request(mc, PEER_PUBLIC_KEY.hex())
+
+        command = mc.commands.send.await_args.args[0]
+        assert command == b"\x39" + PEER_PUBLIC_KEY + b"\x01\x00"
+
+
+class TestSnapshotContract:
+    def test_timestamp_uses_six_digits_and_explicit_utc_offset(self):
+        assert _format_snapshot_timestamp(1_700_000_000).endswith(".000000+00:00")
+
+    def test_self_scope_normalization_preserves_wildcard_and_dollar(self):
+        assert normalize_self_scopes(" #*, #$private, Sweden ") == "*,$private,Sweden"
+
+    def test_snapshot_orders_by_age_then_snr_then_key(self, monkeypatch):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a",
+            {"neighbor_origin": "' Observer '", "neighbor_self_scopes": "#*, #Sweden"},
+        )
+        entries = [
+            ScopeQueryEntry("CC" * 32, heard_timestamp=90, snr_q4=4, status="timeout"),
+            ScopeQueryEntry("BB" * 32, heard_timestamp=95, snr_q4=4, status="send_failed"),
+            ScopeQueryEntry(
+                "AA" * 32, heard_timestamp=95, snr_q4=12, scopes="Europe", status="responded"
+            ),
+        ]
+        monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
+
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            serialized = reporter._build_snapshot(entries, {"a"})
+
+        assert serialized is not None
+        snapshot = json.loads(serialized)
+        assert snapshot["origin"] == "Observer"
+        assert snapshot["origin_id"] == OUR_PUBLIC_KEY.hex().upper()
+        assert snapshot["self"] == {"scopes": "*,Sweden"}
+        assert [neighbor["pubkey"] for neighbor in snapshot["neighbors"]] == [
+            "AA" * 32,
+            "BB" * 32,
+            "CC" * 32,
+        ]
+
+    def test_snapshot_never_includes_observer_identity(self, monkeypatch):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module("a", {})
+        monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
+
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            serialized = reporter._build_snapshot(
+                [
+                    ScopeQueryEntry(
+                        OUR_PUBLIC_KEY.hex(),
+                        heard_timestamp=90,
+                        snr_q4=4,
+                        status="timeout",
+                    )
+                ],
+                {"a"},
+            )
+
+        assert serialized is not None
+        assert json.loads(serialized)["neighbors"] == []
+
+    def test_snapshot_buffer_boundary_is_not_accepted(self, monkeypatch):
+        reporter = CommunityNeighborReporter()
+        payload = {"x": "a"}
+        serialized = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+        monkeypatch.setattr("app.fanout.community_neighbors.MAX_SNAPSHOT_BYTES", len(serialized))
+
+        assert reporter._serialize_snapshot(payload) is None
+
+    def test_due_status_distinguishes_waiting_for_a_broker(self):
+        reporter = CommunityNeighborReporter()
+        reporter._next_periodic_at = 0
+
+        assert reporter.status_for("missing")["phase"] == "due"
+
+    def test_status_reports_serialized_publish_handoff(self):
+        reporter = CommunityNeighborReporter()
+        reporter._publishing_snapshot = True
+
+        assert reporter.status_for("missing")["phase"] == "publishing"
+
+
+class TestSnapshotHandoff:
+    @pytest.mark.asyncio
+    async def test_manual_snapshot_does_not_overtake_an_in_flight_publish(self):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["one"] = _Module("one", {}, connected=True)
+        reporter._publishing_snapshot = True
+
+        result = await reporter.start_manual_snapshot("one")
+
+        assert result["status"] == "active"
+        assert "still publishing" in result["message"]
+
+    def test_reconnecting_slot_stays_eligible_until_publication(self):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["connected"] = _Module("connected", {}, connected=True)
+        reporter._modules["reconnecting"] = _Module("reconnecting", {}, connected=False)
+
+        assert reporter._eligible_publish_target_ids(
+            {"connected", "reconnecting"}, include_manual=True
+        ) == {"connected", "reconnecting"}
+
+
+class TestMqttNeighborDelivery:
+    @pytest.mark.asyncio
+    async def test_module_publishes_snapshot_qos_one_to_neighbor_topic(self):
+        module = MqttCommunityModule(
+            "one",
+            {
+                "iata": "STO",
+                "neighbor_topic_template": DEFAULT_NEIGHBOR_TOPIC,
+                "neighbor_retain": True,
+            },
+        )
+        module._publisher.connected = True
+        module._publisher._settings = SimpleNamespace()
+        module._publisher.publish = AsyncMock(return_value=True)
+
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            assert await module.publish_neighbor_snapshot('{"neighbors":[]}')
+
+        module._publisher.publish.assert_awaited_once_with(
+            f"meshcore/STO/{OUR_PUBLIC_KEY.hex().upper()}/neighbors",
+            '{"neighbors":[]}',
+            retain=True,
+            qos=1,
+        )
+
+    def test_neighbor_template_renders_type_placeholder(self):
+        assert (
+            _render_neighbor_topic("mesh/{iata}/{device}/{type}", iata="STO", public_key="AB" * 32)
+            == f"mesh/STO/{'AB' * 32}/neighbors"
+        )
+
+    def test_neighbor_template_requires_neighbors_suffix(self):
+        with pytest.raises(ValueError, match="must end with /neighbors or /\\{TYPE\\}"):
+            _render_neighbor_topic("mesh/{iata}/{device}/packets", iata="STO", public_key="AB" * 32)
+
+
+class TestNeighborConfigValidation:
+    def test_defaults_are_persisted_for_existing_community_configs(self):
+        from app.routers.fanout import _validate_mqtt_community_config
+
+        config = {"iata": "sto"}
+        _validate_mqtt_community_config(config)
+
+        assert config["neighbor_reporting_enabled"] is False
+        assert config["neighbor_reporting_interval_hours"] == 24
+        assert config["neighbor_topic_template"] == DEFAULT_NEIGHBOR_TOPIC
+        assert config["neighbor_retain"] is False
+
+    def test_interval_range_is_enforced(self):
+        from app.routers.fanout import _validate_mqtt_community_config
+
+        with pytest.raises(HTTPException, match="between 12 and 336"):
+            _validate_mqtt_community_config(
+                {"iata": "STO", "neighbor_reporting_interval_hours": 11}
+            )
+
+    def test_neighbor_topic_must_be_a_string(self):
+        from app.routers.fanout import _validate_mqtt_community_config
+
+        with pytest.raises(HTTPException, match="neighbor_topic_template must be a string"):
+            _validate_mqtt_community_config({"iata": "STO", "neighbor_topic_template": 42})
+
+    def test_neighbor_topic_must_keep_the_neighbors_suffix(self):
+        from app.routers.fanout import _validate_mqtt_community_config
+
+        with pytest.raises(HTTPException, match="must end with /neighbors or /\\{TYPE\\}"):
+            _validate_mqtt_community_config(
+                {"iata": "STO", "neighbor_topic_template": "mesh/{IATA}/{PUBLIC_KEY}/packets"}
+            )

--- a/tests/test_community_neighbors.py
+++ b/tests/test_community_neighbors.py
@@ -169,9 +169,7 @@ class TestScopeResponseOverlay:
             patch("app.keystore.get_private_key", return_value=OUR_PRIVATE_KEY),
             patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
         ):
-            await reporter.observe_packet(
-                _response_packet(tag=first_tag, scopes=b"Europe")
-            )
+            await reporter.observe_packet(_response_packet(tag=first_tag, scopes=b"Europe"))
             await reporter.observe_packet(
                 _response_packet(
                     tag=second_tag,
@@ -365,9 +363,7 @@ class TestMqttNeighborDelivery:
 
     def test_neighbor_template_preserves_escaped_literal_braces(self):
         assert (
-            _render_neighbor_topic(
-                "mesh/{{literal}}/{type}", iata="STO", public_key="AB" * 32
-            )
+            _render_neighbor_topic("mesh/{{literal}}/{type}", iata="STO", public_key="AB" * 32)
             == "mesh/{literal}/neighbors"
         )
 

--- a/tests/test_community_neighbors.py
+++ b/tests/test_community_neighbors.py
@@ -184,12 +184,10 @@ class TestSnapshotContract:
     def test_self_scope_normalization_preserves_wildcard_and_dollar(self):
         assert normalize_self_scopes(" #*, #$private, Sweden ") == "*,$private,Sweden"
 
-    def test_snapshot_orders_by_age_then_snr_then_key(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_snapshot_orders_by_age_then_snr_then_key(self, monkeypatch):
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module(
-            "a",
-            {"neighbor_origin": "' Observer '", "neighbor_self_scopes": "#*, #Sweden"},
-        )
+        reporter._modules["a"] = _Module("a", {})
         entries = [
             ScopeQueryEntry("CC" * 32, heard_timestamp=90, snr_q4=4, status="timeout"),
             ScopeQueryEntry("BB" * 32, heard_timestamp=95, snr_q4=4, status="send_failed"),
@@ -199,12 +197,18 @@ class TestSnapshotContract:
         ]
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
 
-        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = reporter._build_snapshot(entries, {"a"})
+        with (
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+            patch(
+                "app.fanout.community_neighbors._derive_self_scopes",
+                new=AsyncMock(return_value="*,Sweden"),
+            ),
+        ):
+            serialized = await reporter._build_snapshot(entries, {"a"})
 
         assert serialized is not None
         snapshot = json.loads(serialized)
-        assert snapshot["origin"] == "Observer"
+        assert snapshot["origin"] == "MeshCore Device"
         assert snapshot["origin_id"] == OUR_PUBLIC_KEY.hex().upper()
         assert snapshot["self"] == {"scopes": "*,Sweden"}
         assert [neighbor["pubkey"] for neighbor in snapshot["neighbors"]] == [
@@ -213,13 +217,20 @@ class TestSnapshotContract:
             "CC" * 32,
         ]
 
-    def test_snapshot_never_includes_observer_identity(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_snapshot_never_includes_observer_identity(self, monkeypatch):
         reporter = CommunityNeighborReporter()
         reporter._modules["a"] = _Module("a", {})
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
 
-        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = reporter._build_snapshot(
+        with (
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+            patch(
+                "app.fanout.community_neighbors._derive_self_scopes",
+                new=AsyncMock(return_value="*"),
+            ),
+        ):
+            serialized = await reporter._build_snapshot(
                 [
                     ScopeQueryEntry(
                         OUR_PUBLIC_KEY.hex(),

--- a/tests/test_community_neighbors.py
+++ b/tests/test_community_neighbors.py
@@ -34,6 +34,7 @@ OUR_PRIVATE_KEY = bytes.fromhex(
     "77ACADDB84438514022BDB0FC3140C2501859BE1772AC7B8C7E41DC0F40490A1"
 )
 PEER_PUBLIC_KEY = bytes.fromhex("A1B2C3D3BA9F5FA8705B9845FE11CC6F01D1D49CAAF4D122AC7121663C5BEEC7")
+PEER_TWO_PUBLIC_KEY = derive_public_key(bytes(range(64)))
 OUR_PUBLIC_KEY = derive_public_key(OUR_PRIVATE_KEY)
 
 
@@ -49,14 +50,16 @@ class _Module:
         return True
 
 
-def _response_packet(*, tag: bytes, scopes: bytes) -> bytes:
+def _response_packet(
+    *, tag: bytes, scopes: bytes, peer_public_key: bytes = PEER_PUBLIC_KEY
+) -> bytes:
     """Build one authenticated direct PAYLOAD_TYPE_RESPONSE packet."""
     plaintext = tag + (1_700_000_000).to_bytes(4, "little") + scopes
     plaintext += bytes((-len(plaintext)) % 16)
-    secret = derive_shared_secret(OUR_PRIVATE_KEY, PEER_PUBLIC_KEY)
+    secret = derive_shared_secret(OUR_PRIVATE_KEY, peer_public_key)
     ciphertext = AES.new(secret[:16], AES.MODE_ECB).encrypt(plaintext)
     mac = hmac.new(secret, ciphertext, sha256).digest()[:2]
-    payload = bytes((OUR_PUBLIC_KEY[0], PEER_PUBLIC_KEY[0])) + mac + ciphertext
+    payload = bytes((OUR_PUBLIC_KEY[0], peer_public_key[0])) + mac + ciphertext
     # Header: direct route + response payload type, followed by zero hops.
     return bytes(((int(PayloadType.RESPONSE) << 2) | 0x02, 0)) + payload
 
@@ -130,7 +133,6 @@ class TestScopeResponseOverlay:
         )
         reporter._scope_active = True
         reporter._scope_entries = [entry]
-        reporter._queries_by_tag[entry.request_tag] = entry
 
         with (
             patch("app.keystore.get_private_key", return_value=OUR_PRIVATE_KEY),
@@ -140,6 +142,48 @@ class TestScopeResponseOverlay:
 
         assert entry.status == "responded"
         assert entry.scopes == "*,Europe"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_batch_allows_same_tag_for_different_peers(self):
+        reporter = CommunityNeighborReporter()
+        first_tag = bytes.fromhex("01020304")
+        second_tag = first_tag
+        entries = [
+            ScopeQueryEntry(
+                public_key=PEER_PUBLIC_KEY.hex(),
+                heard_timestamp=100,
+                snr_q4=8,
+                request_tag=first_tag.hex(),
+            ),
+            ScopeQueryEntry(
+                public_key=PEER_TWO_PUBLIC_KEY.hex(),
+                heard_timestamp=101,
+                snr_q4=4,
+                request_tag=second_tag.hex(),
+            ),
+        ]
+        reporter._scope_active = True
+        reporter._scope_entries = entries
+
+        with (
+            patch("app.keystore.get_private_key", return_value=OUR_PRIVATE_KEY),
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+        ):
+            await reporter.observe_packet(
+                _response_packet(tag=first_tag, scopes=b"Europe")
+            )
+            await reporter.observe_packet(
+                _response_packet(
+                    tag=second_tag,
+                    scopes=b"Sweden",
+                    peer_public_key=PEER_TWO_PUBLIC_KEY,
+                )
+            )
+
+        assert [(entry.status, entry.scopes) for entry in entries] == [
+            ("responded", "Europe"),
+            ("responded", "Sweden"),
+        ]
 
     @pytest.mark.asyncio
     async def test_wrong_tag_does_not_complete_overlay_entry(self):
@@ -152,7 +196,6 @@ class TestScopeResponseOverlay:
         )
         reporter._scope_active = True
         reporter._scope_entries = [entry]
-        reporter._queries_by_tag[entry.request_tag] = entry
 
         with (
             patch("app.keystore.get_private_key", return_value=OUR_PRIVATE_KEY),
@@ -184,10 +227,12 @@ class TestSnapshotContract:
     def test_self_scope_normalization_preserves_wildcard_and_dollar(self):
         assert normalize_self_scopes(" #*, #$private, Sweden ") == "*,$private,Sweden"
 
-    @pytest.mark.asyncio
-    async def test_snapshot_orders_by_age_then_snr_then_key(self, monkeypatch):
+    def test_snapshot_orders_by_age_then_snr_then_key(self, monkeypatch):
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module("a", {})
+        reporter._modules["a"] = _Module(
+            "a",
+            {"neighbor_origin": "' Observer '", "neighbor_self_scopes": "#*, #Sweden"},
+        )
         entries = [
             ScopeQueryEntry("CC" * 32, heard_timestamp=90, snr_q4=4, status="timeout"),
             ScopeQueryEntry("BB" * 32, heard_timestamp=95, snr_q4=4, status="send_failed"),
@@ -197,18 +242,12 @@ class TestSnapshotContract:
         ]
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
 
-        with (
-            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
-            patch(
-                "app.fanout.community_neighbors._derive_self_scopes",
-                new=AsyncMock(return_value="*,Sweden"),
-            ),
-        ):
-            serialized = await reporter._build_snapshot(entries, {"a"})
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            serialized = reporter._build_snapshot(entries, {"a"})
 
         assert serialized is not None
         snapshot = json.loads(serialized)
-        assert snapshot["origin"] == "MeshCore Device"
+        assert snapshot["origin"] == "Observer"
         assert snapshot["origin_id"] == OUR_PUBLIC_KEY.hex().upper()
         assert snapshot["self"] == {"scopes": "*,Sweden"}
         assert [neighbor["pubkey"] for neighbor in snapshot["neighbors"]] == [
@@ -217,20 +256,13 @@ class TestSnapshotContract:
             "CC" * 32,
         ]
 
-    @pytest.mark.asyncio
-    async def test_snapshot_never_includes_observer_identity(self, monkeypatch):
+    def test_snapshot_never_includes_observer_identity(self, monkeypatch):
         reporter = CommunityNeighborReporter()
         reporter._modules["a"] = _Module("a", {})
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
 
-        with (
-            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
-            patch(
-                "app.fanout.community_neighbors._derive_self_scopes",
-                new=AsyncMock(return_value="*"),
-            ),
-        ):
-            serialized = await reporter._build_snapshot(
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            serialized = reporter._build_snapshot(
                 [
                     ScopeQueryEntry(
                         OUR_PUBLIC_KEY.hex(),
@@ -322,6 +354,27 @@ class TestMqttNeighborDelivery:
     def test_neighbor_template_requires_neighbors_suffix(self):
         with pytest.raises(ValueError, match="must end with /neighbors or /\\{TYPE\\}"):
             _render_neighbor_topic("mesh/{iata}/{device}/packets", iata="STO", public_key="AB" * 32)
+
+    def test_neighbor_template_rejects_placeholder_formatting(self):
+        with pytest.raises(ValueError, match="do not support formatting"):
+            _render_neighbor_topic(
+                "mesh/{iata}/{device:.12}/neighbors",
+                iata="STO",
+                public_key="AB" * 32,
+            )
+
+    def test_neighbor_template_preserves_escaped_literal_braces(self):
+        assert (
+            _render_neighbor_topic(
+                "mesh/{{literal}}/{type}", iata="STO", public_key="AB" * 32
+            )
+            == "mesh/{literal}/neighbors"
+        )
+
+    @pytest.mark.parametrize("template", ["mesh/+/neighbors", "mesh/#/neighbors"])
+    def test_neighbor_template_rejects_publish_wildcards(self, template):
+        with pytest.raises(ValueError, match="cannot contain MQTT wildcards"):
+            _render_neighbor_topic(template, iata="STO", public_key="AB" * 32)
 
 
 class TestNeighborConfigValidation:

--- a/tests/test_community_neighbors_comprehensive.py
+++ b/tests/test_community_neighbors_comprehensive.py
@@ -83,16 +83,6 @@ def _make_envelope(
     )
 
 
-@pytest.fixture(autouse=True)
-def _mock_derive_self_scopes():
-    """Block the real DB call in every snapshot-building test."""
-    with patch(
-        "app.fanout.community_neighbors._derive_self_scopes",
-        new=AsyncMock(return_value="*"),
-    ):
-        yield
-
-
 # ===================================================================
 # S25.1 / S25.2  Cache & discovery tests
 # ===================================================================
@@ -174,6 +164,11 @@ class TestCacheExtended:
         assert _quantize_snr(50.0) == 127
         assert _quantize_snr(-50.0) == -128
 
+    def test_non_finite_snr_is_safely_normalized(self):
+        assert _quantize_snr(float("nan")) == 0
+        assert _quantize_snr(float("inf")) == 0
+        assert _quantize_snr(float("-inf")) == 0
+
     @pytest.mark.asyncio
     async def test_cache_survives_refresh_cycle(self):
         """Spec 25.1-9: stale cache entry remains after refresh completes."""
@@ -238,13 +233,15 @@ class TestCacheExtended:
             await reporter.observe_packet(b"raw")
         assert reporter._cache == {}
 
-    def test_observation_id_dedup_eviction_at_256(self):
-        """Spec 35-62: observation-ID set prunes beyond 256 entries."""
+    def test_early_scope_response_buffer_is_bounded_and_deduplicated(self):
+        """The raw-response handoff buffer stays bounded without packet-ID state."""
         reporter = CommunityNeighborReporter()
-        for i in range(300):
-            reporter._remember_observation_id(i)
-        assert len(reporter._seen_observation_ids) <= 256
-        assert 0 not in reporter._seen_observation_ids
+        for i in range(70):
+            reporter._remember_early_scope_response(i.to_bytes(2, "little"))
+        reporter._remember_early_scope_response((69).to_bytes(2, "little"))
+        assert len(reporter._early_scope_responses) == 64
+        assert (0).to_bytes(2, "little") not in reporter._early_scope_responses
+        assert reporter._early_scope_responses.count((69).to_bytes(2, "little")) == 1
 
 
 class TestDiscoveryResponseValidation:
@@ -367,6 +364,21 @@ class TestDiscoveryResponseValidation:
         assert PEER_PUBLIC_KEY.hex().lower() not in reporter._cache
 
     @pytest.mark.asyncio
+    async def test_discovery_response_reserved_path_mode_ignored(self):
+        reporter = CommunityNeighborReporter()
+        reporter._discovery_tag = 42
+        reporter._discovery_deadline = 999999.0
+        payload = {
+            "node_type": 2,
+            "path_len": 0xC0,
+            "tag": (42).to_bytes(4, "little").hex(),
+            "pubkey": PEER_PUBLIC_KEY.hex(),
+            "SNR": 5.0,
+        }
+        await reporter._observe_discovery_response(payload)
+        assert PEER_PUBLIC_KEY.hex().lower() not in reporter._cache
+
+    @pytest.mark.asyncio
     async def test_none_discovery_tag_ignored(self):
         """No active discovery tag -> response ignored."""
         reporter = CommunityNeighborReporter()
@@ -420,11 +432,53 @@ class TestScopeQueryPhase:
         with (
             patch.object(reporter, "_send_regions_request", fake_send),
             patch("app.services.radio_runtime.radio_runtime.radio_operation", fake_radio_op),
+            patch("app.keystore.get_private_key", return_value=OUR_PRIVATE_KEY),
             patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
         ):
             await reporter._begin_scope_queries(target_ids={"x"}, periodic=False, manual=True)
 
         assert seen_keys == {key_a, key_b}
+
+    @pytest.mark.asyncio
+    async def test_manual_scope_query_rejects_missing_private_key(self):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["x"] = _Module("x", {}, connected=True)
+        await reporter.put_neighbor(
+            "aa" * 32, advert_timestamp=1, measured_snr=1, heard_timestamp=10
+        )
+
+        with (
+            patch("app.keystore.get_private_key", return_value=None),
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+            pytest.raises(NeighborReporterError, match="requires the radio private key"),
+        ):
+            await reporter._begin_scope_queries(
+                target_ids={"x"}, periodic=False, manual=True
+            )
+
+        assert reporter._scope_active is False
+
+    @pytest.mark.asyncio
+    async def test_periodic_scope_query_defers_when_private_key_is_missing(self):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["x"] = _Module(
+            "x", {"neighbor_reporting_enabled": True}, connected=True
+        )
+        await reporter.put_neighbor(
+            "aa" * 32, advert_timestamp=1, measured_snr=1, heard_timestamp=10
+        )
+
+        with (
+            patch("app.keystore.get_private_key", return_value=None),
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+        ):
+            await reporter._begin_scope_queries(
+                target_ids={"x"}, periodic=True, manual=False
+            )
+
+        assert reporter._scope_active is False
+        assert reporter._last_publish_result == "failed"
+        assert reporter._next_periodic_at is not None
 
     @pytest.mark.asyncio
     async def test_send_allocation_failure_becomes_send_failed(self):
@@ -447,6 +501,7 @@ class TestScopeQueryPhase:
         with (
             patch.object(reporter, "_send_regions_request", failing_send),
             patch("app.services.radio_runtime.radio_runtime.radio_operation", fake_radio_op),
+            patch("app.keystore.get_private_key", return_value=OUR_PRIVATE_KEY),
             patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
         ):
             await reporter._begin_scope_queries(target_ids={"x"}, periodic=False, manual=True)
@@ -469,7 +524,6 @@ class TestScopeQueryPhase:
         )
         reporter._scope_active = True
         reporter._scope_entries = [entry]
-        reporter._queries_by_tag[entry.request_tag] = entry
 
         with (
             patch("app.keystore.get_private_key", return_value=OUR_PRIVATE_KEY),
@@ -562,11 +616,16 @@ class TestScopeQueryPhase:
 
 
 class TestJsonContractComprehensive:
-    @pytest.mark.asyncio
-    async def test_required_fields_present(self, monkeypatch):
+    def test_required_fields_present(self, monkeypatch):
         """Spec 25.4-30: all required fields present in root + neighbor."""
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module("a", {})
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_origin": "Test",
+                "neighbor_self_scopes": "EU,US",
+            },
+        )
         entries = [
             ScopeQueryEntry(
                 "AA" * 32, heard_timestamp=90, snr_q4=8, scopes="EU", status="responded"
@@ -575,7 +634,7 @@ class TestJsonContractComprehensive:
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
 
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = await reporter._build_snapshot(entries, {"a"})
+            serialized = reporter._build_snapshot(entries, {"a"})
 
         assert serialized is not None
         snapshot = json.loads(serialized)
@@ -590,8 +649,7 @@ class TestJsonContractComprehensive:
         for field in ("pubkey", "snr", "heard_secs_ago", "scopes", "status"):
             assert field in neighbor, f"missing {field}"
 
-    @pytest.mark.asyncio
-    async def test_clock_backward_clamp(self, monkeypatch):
+    def test_clock_backward_clamp(self, monkeypatch):
         """Spec 25.4-33: future heard_timestamp -> age 0."""
         reporter = CommunityNeighborReporter()
         reporter._modules["a"] = _Module("a", {})
@@ -600,12 +658,11 @@ class TestJsonContractComprehensive:
             ScopeQueryEntry("AA" * 32, heard_timestamp=200, snr_q4=8, status="responded"),
         ]
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = await reporter._build_snapshot(entries, {"a"})
+            serialized = reporter._build_snapshot(entries, {"a"})
         snapshot = json.loads(serialized)
         assert snapshot["neighbors"][0]["heard_secs_ago"] == 0
 
-    @pytest.mark.asyncio
-    async def test_pubkey_lexical_tie_break(self, monkeypatch):
+    def test_pubkey_lexical_tie_break(self, monkeypatch):
         """Spec 25.4-36: pubkey tie-break is deterministic."""
         reporter = CommunityNeighborReporter()
         reporter._modules["a"] = _Module("a", {})
@@ -616,15 +673,20 @@ class TestJsonContractComprehensive:
             ScopeQueryEntry("AA" * 32, heard_timestamp=95, snr_q4=8, status="timeout"),
         ]
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = await reporter._build_snapshot(entries, {"a"})
+            serialized = reporter._build_snapshot(entries, {"a"})
         keys = [n["pubkey"] for n in json.loads(serialized)["neighbors"]]
         assert keys == ["AA" * 32, "BB" * 32, "CC" * 32]
 
-    @pytest.mark.asyncio
-    async def test_json_escaping_handles_quotes_in_scopes(self, monkeypatch):
+    def test_json_escaping_handles_quotes_in_scopes(self, monkeypatch):
         """Spec 25.4-37: unusual scope chars are JSON-safe."""
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module("a", {})
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_self_scopes": "a",
+                "neighbor_origin": "B",
+            },
+        )
         entries = [
             ScopeQueryEntry(
                 "AA" * 32, heard_timestamp=90, snr_q4=8, scopes='foo"bar', status="responded"
@@ -632,14 +694,19 @@ class TestJsonContractComprehensive:
         ]
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = await reporter._build_snapshot(entries, {"a"})
+            serialized = reporter._build_snapshot(entries, {"a"})
         snapshot = json.loads(serialized)
         assert snapshot["neighbors"][0]["scopes"] == 'foo"bar'
 
-    @pytest.mark.asyncio
-    async def test_scopes_with_backslash_survive_roundtrip(self, monkeypatch):
+    def test_scopes_with_backslash_survive_roundtrip(self, monkeypatch):
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module("a", {})
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_self_scopes": "a",
+                "neighbor_origin": "B",
+            },
+        )
         entries = [
             ScopeQueryEntry(
                 "AA" * 32, heard_timestamp=90, snr_q4=8, scopes="path\\trail", status="responded"
@@ -647,15 +714,20 @@ class TestJsonContractComprehensive:
         ]
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = await reporter._build_snapshot(entries, {"a"})
+            serialized = reporter._build_snapshot(entries, {"a"})
         snapshot = json.loads(serialized)
         assert snapshot["neighbors"][0]["scopes"] == "path\\trail"
 
-    @pytest.mark.asyncio
-    async def test_progressive_truncation_leaves_valid_json(self, monkeypatch):
+    def test_progressive_truncation_leaves_valid_json(self, monkeypatch):
         """Spec 25.4-38: tail removed, valid JSON remains."""
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module("a", {})
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_origin": "O",
+                "neighbor_self_scopes": "S",
+            },
+        )
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
 
         entries = [
@@ -663,7 +735,7 @@ class TestJsonContractComprehensive:
             for i in range(200)
         ]
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = await reporter._build_snapshot(entries, {"a"})
+            serialized = reporter._build_snapshot(entries, {"a"})
 
         assert serialized is not None
         snapshot = json.loads(serialized)
@@ -671,14 +743,19 @@ class TestJsonContractComprehensive:
         encoded = serialized.encode("utf-8")
         assert 0 < len(encoded) < MAX_SNAPSHOT_BYTES
 
-    @pytest.mark.asyncio
-    async def test_root_object_too_large_fails_cleanly(self, monkeypatch):
+    def test_root_object_too_large_fails_cleanly(self, monkeypatch):
         """Spec 25.4-39: root too large -> None."""
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module("a", {})
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_origin": "N",
+                "neighbor_self_scopes": "x",
+            },
+        )
         monkeypatch.setattr("app.fanout.community_neighbors.MAX_SNAPSHOT_BYTES", 20)
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = await reporter._build_snapshot([], {"a"})
+            serialized = reporter._build_snapshot([], {"a"})
         assert serialized is None
 
     def test_origin_quote_stripping(self):
@@ -691,8 +768,24 @@ class TestJsonContractComprehensive:
         assert normalize_neighbor_origin(None) == ""
         assert normalize_neighbor_origin("") == ""
 
-    @pytest.mark.asyncio
-    async def test_snr_is_float_not_string(self, monkeypatch):
+    def test_quoted_device_name_fallback_is_normalized(self, monkeypatch):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module("a", {"neighbor_origin": ""})
+        monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
+
+        with (
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+            patch(
+                "app.radio.radio_manager._meshcore",
+                SimpleNamespace(self_info={"name": "'Observer'"}),
+            ),
+        ):
+            serialized = reporter._build_snapshot([], {"a"})
+
+        assert serialized is not None
+        assert json.loads(serialized)["origin"] == "Observer"
+
+    def test_snr_is_float_not_string(self, monkeypatch):
         """SNR is a JSON number, not string."""
         reporter = CommunityNeighborReporter()
         reporter._modules["a"] = _Module("a", {})
@@ -701,14 +794,13 @@ class TestJsonContractComprehensive:
             ScopeQueryEntry("AA" * 32, heard_timestamp=90, snr_q4=10, status="responded"),
         ]
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = await reporter._build_snapshot(entries, {"a"})
+            serialized = reporter._build_snapshot(entries, {"a"})
         snapshot = json.loads(serialized)
         snr = snapshot["neighbors"][0]["snr"]
         assert isinstance(snr, (int, float))
         assert snr == 2.5
 
-    @pytest.mark.asyncio
-    async def test_heard_secs_ago_is_int(self, monkeypatch):
+    def test_heard_secs_ago_is_int(self, monkeypatch):
         reporter = CommunityNeighborReporter()
         reporter._modules["a"] = _Module("a", {})
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
@@ -716,12 +808,11 @@ class TestJsonContractComprehensive:
             ScopeQueryEntry("AA" * 32, heard_timestamp=90, snr_q4=4, status="timeout"),
         ]
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = await reporter._build_snapshot(entries, {"a"})
+            serialized = reporter._build_snapshot(entries, {"a"})
         snapshot = json.loads(serialized)
         assert isinstance(snapshot["neighbors"][0]["heard_secs_ago"], int)
 
-    @pytest.mark.asyncio
-    async def test_status_is_valid_enum(self, monkeypatch):
+    def test_status_is_valid_enum(self, monkeypatch):
         reporter = CommunityNeighborReporter()
         reporter._modules["a"] = _Module("a", {})
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
@@ -730,7 +821,7 @@ class TestJsonContractComprehensive:
                 ScopeQueryEntry("AA" * 32, heard_timestamp=90, snr_q4=4, status=status),
             ]
             with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-                serialized = await reporter._build_snapshot(entries, {"a"})
+                serialized = reporter._build_snapshot(entries, {"a"})
             assert status in serialized
 
 
@@ -801,6 +892,22 @@ class TestMqttDelivery:
         result = await reporter.start_manual_snapshot("one")
         assert result["status"] == "active"
         assert "still publishing" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_build_exception_releases_snapshot_handoff(self):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["one"] = _Module("one", {})
+        reporter._scope_active = True
+        reporter._scope_entries = [
+            ScopeQueryEntry("AA" * 32, heard_timestamp=10, snr_q4=4, status="responded")
+        ]
+        reporter._scope_target_ids = {"one"}
+
+        with patch.object(reporter, "_build_snapshot", side_effect=RuntimeError("boom")):
+            await reporter._finish_scope_queries(timeout=False)
+
+        assert reporter._publishing_snapshot is False
+        assert reporter._last_publish_result == "failed"
 
 
 # ===================================================================
@@ -918,6 +1025,55 @@ class TestScheduling:
         reporter._discovery_deadline = 999999.0
         result = await reporter.start_manual_discovery("a")
         assert result["status"] == "joined"
+        assert reporter._discovery_manual is True
+
+    @pytest.mark.asyncio
+    async def test_disabling_periodic_does_not_cancel_manual_owner(self):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a", {"neighbor_reporting_enabled": False}
+        )
+        reporter._discovery_tag = 42
+        reporter._discovery_deadline = 999999999.0
+        reporter._discovery_periodic = True
+
+        await reporter.start_manual_discovery("a")
+        await reporter._tick()
+
+        assert reporter._discovery_tag == 42
+        assert reporter._discovery_manual is True
+        assert reporter._discovery_periodic is False
+
+    @pytest.mark.asyncio
+    async def test_disabling_periodic_keeps_manual_scope_ownership(self):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a", {"neighbor_reporting_enabled": False}
+        )
+        reporter._discovery_tag = 42
+        reporter._discovery_deadline = 999999999.0
+        reporter._discovery_periodic = True
+
+        await reporter.start_manual_snapshot("a")
+        await reporter._tick()
+
+        assert reporter._discovery_tag == 42
+        assert reporter._discovery_periodic is False
+        assert reporter._discovery_manual_scope is True
+
+    @pytest.mark.asyncio
+    async def test_disabling_periodic_cancels_pure_periodic_refresh(self):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a", {"neighbor_reporting_enabled": False}
+        )
+        reporter._discovery_tag = 42
+        reporter._discovery_deadline = 999999999.0
+        reporter._discovery_periodic = True
+
+        await reporter._tick()
+
+        assert reporter._discovery_tag is None
 
     @pytest.mark.asyncio
     async def test_manual_snapshot_queues_behind_active_refresh(self):
@@ -966,6 +1122,7 @@ class TestSharedCoordinator:
         with (
             patch.object(reporter, "_send_regions_request", fake_send),
             patch("app.services.radio_runtime.radio_runtime.radio_operation", fake_radio_op),
+            patch("app.keystore.get_private_key", return_value=OUR_PRIVATE_KEY),
             patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
         ):
             await reporter._begin_scope_queries(target_ids={"a", "b"}, periodic=True, manual=False)
@@ -1004,6 +1161,7 @@ class TestSharedCoordinator:
         with (
             patch.object(reporter, "_send_regions_request", fake_send),
             patch("app.services.radio_runtime.radio_runtime.radio_operation", fake_radio_op),
+            patch("app.keystore.get_private_key", return_value=OUR_PRIVATE_KEY),
             patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
         ):
             await reporter._begin_scope_queries(
@@ -1052,6 +1210,20 @@ class TestSharedCoordinator:
         assert reporter.status_for("a")["phase"] == "refresh"
 
     @pytest.mark.asyncio
+    async def test_manual_snapshot_can_use_another_connected_broker(self):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["requested"] = _Module("requested", {}, connected=False)
+        reporter._modules["available"] = _Module("available", {}, connected=True)
+
+        with patch.object(reporter, "_begin_scope_queries", new=AsyncMock()) as begin:
+            result = await reporter.start_manual_snapshot("requested")
+
+        assert result["status"] == "started"
+        begin.assert_awaited_once_with(
+            target_ids={"requested", "available"}, periodic=False, manual=True
+        )
+
+    @pytest.mark.asyncio
     async def test_scope_queries_blocked_when_bridge_not_connected(self):
         """Spec 22.2: manual scope request rejected when bridge not connected."""
         reporter = CommunityNeighborReporter()
@@ -1059,6 +1231,37 @@ class TestSharedCoordinator:
         reporter._modules["a"] = module
         with pytest.raises(NeighborReporterError, match="not running"):
             await reporter.start_manual_snapshot("a")
+
+    @pytest.mark.asyncio
+    async def test_periodic_scope_stays_due_while_previous_snapshot_publishes(self, monkeypatch):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["on"] = _Module(
+            "on", {"neighbor_reporting_enabled": True}, connected=True
+        )
+        reporter._publishing_snapshot = True
+        monkeypatch.setattr("app.fanout.community_neighbors._monotonic", lambda: 122.0)
+
+        await reporter._begin_scope_queries(
+            target_ids={"on"}, periodic=True, manual=False
+        )
+
+        assert reporter._scope_active is False
+        assert reporter._next_periodic_at == 122.0
+
+    @pytest.mark.asyncio
+    async def test_periodic_scope_stays_due_when_broker_drops_after_refresh(self, monkeypatch):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["off"] = _Module(
+            "off", {"neighbor_reporting_enabled": True}, connected=False
+        )
+        monkeypatch.setattr("app.fanout.community_neighbors._monotonic", lambda: 123.0)
+
+        await reporter._begin_scope_queries(
+            target_ids={"off"}, periodic=True, manual=False
+        )
+
+        assert reporter._scope_active is False
+        assert reporter._next_periodic_at == 123.0
 
     @pytest.mark.asyncio
     async def test_begin_scope_checks_connected_broker_exists(self):
@@ -1071,6 +1274,27 @@ class TestSharedCoordinator:
 
         with pytest.raises(NeighborReporterError, match="not running"):
             await reporter._begin_scope_queries(target_ids={"off"}, periodic=False, manual=True)
+
+    @pytest.mark.asyncio
+    async def test_reporter_loop_survives_one_tick_failure(self):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["x"] = _Module("x", {})
+        calls = 0
+
+        async def fake_tick():
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise RuntimeError("transient")
+            reporter._modules.clear()
+
+        with (
+            patch.object(reporter, "_tick", side_effect=fake_tick),
+            patch("app.fanout.community_neighbors.asyncio.sleep", new=AsyncMock()),
+        ):
+            await reporter._run()
+
+        assert calls == 2
 
 
 # ===================================================================
@@ -1101,6 +1325,10 @@ class TestEdgeCases:
     def test_normalize_self_scopes_rejects_control_chars(self):
         with pytest.raises(ValueError):
             normalize_self_scopes(["good", "bad\x01"])
+
+    def test_normalize_self_scopes_rejects_non_string_list_entries(self):
+        with pytest.raises(ValueError, match="entries must be strings"):
+            normalize_self_scopes(["good", 1])
 
     def test_normalize_self_scopes_strips_hash_and_trims(self):
         assert normalize_self_scopes(" #*, #Sweden , ##double") == "*,Sweden,#double"
@@ -1187,7 +1415,6 @@ class TestScopeOverlayAcLNonInterference:
         )
         reporter._scope_active = True
         reporter._scope_entries = [entry]
-        reporter._queries_by_tag[entry.request_tag] = entry
 
         # Build a response with a non-matching tag
         unmatched_tag = bytes.fromhex("DEADBEEF")
@@ -1238,6 +1465,7 @@ class TestScopeQueryEarlyCompletion:
                 "app.services.radio_runtime.radio_runtime.radio_operation",
                 fake_radio_op,
             ),
+            patch("app.keystore.get_private_key", return_value=OUR_PRIVATE_KEY),
             patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
         ):
             await reporter._begin_scope_queries(target_ids={"x"}, periodic=False, manual=True)
@@ -1253,18 +1481,23 @@ class TestScopeQueryEarlyCompletion:
 
 
 class TestJsonKeyFormat:
-    @pytest.mark.asyncio
-    async def test_origin_id_and_pubkey_are_uppercase_64_char_hex(self, monkeypatch):
+    def test_origin_id_and_pubkey_are_uppercase_64_char_hex(self, monkeypatch):
         """Spec 25.4-31: origin_id and pubkey must be uppercase 64-character hex."""
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module("a", {})
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_origin": "Test",
+                "neighbor_self_scopes": "EU",
+            },
+        )
         entries = [
             ScopeQueryEntry("aa" * 32, heard_timestamp=90, snr_q4=8, scopes="", status="responded"),
         ]
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
 
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = await reporter._build_snapshot(entries, {"a"})
+            serialized = reporter._build_snapshot(entries, {"a"})
 
         assert serialized is not None
         snapshot = json.loads(serialized)

--- a/tests/test_community_neighbors_comprehensive.py
+++ b/tests/test_community_neighbors_comprehensive.py
@@ -83,6 +83,16 @@ def _make_envelope(
     )
 
 
+@pytest.fixture(autouse=True)
+def _mock_derive_self_scopes():
+    """Block the real DB call in every snapshot-building test."""
+    with patch(
+        "app.fanout.community_neighbors._derive_self_scopes",
+        new=AsyncMock(return_value="*"),
+    ):
+        yield
+
+
 # ===================================================================
 # S25.1 / S25.2  Cache & discovery tests
 # ===================================================================
@@ -552,16 +562,11 @@ class TestScopeQueryPhase:
 
 
 class TestJsonContractComprehensive:
-    def test_required_fields_present(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_required_fields_present(self, monkeypatch):
         """Spec 25.4-30: all required fields present in root + neighbor."""
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module(
-            "a",
-            {
-                "neighbor_origin": "Test",
-                "neighbor_self_scopes": "EU,US",
-            },
-        )
+        reporter._modules["a"] = _Module("a", {})
         entries = [
             ScopeQueryEntry(
                 "AA" * 32, heard_timestamp=90, snr_q4=8, scopes="EU", status="responded"
@@ -570,7 +575,7 @@ class TestJsonContractComprehensive:
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
 
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = reporter._build_snapshot(entries, {"a"})
+            serialized = await reporter._build_snapshot(entries, {"a"})
 
         assert serialized is not None
         snapshot = json.loads(serialized)
@@ -585,7 +590,8 @@ class TestJsonContractComprehensive:
         for field in ("pubkey", "snr", "heard_secs_ago", "scopes", "status"):
             assert field in neighbor, f"missing {field}"
 
-    def test_clock_backward_clamp(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_clock_backward_clamp(self, monkeypatch):
         """Spec 25.4-33: future heard_timestamp -> age 0."""
         reporter = CommunityNeighborReporter()
         reporter._modules["a"] = _Module("a", {})
@@ -594,11 +600,12 @@ class TestJsonContractComprehensive:
             ScopeQueryEntry("AA" * 32, heard_timestamp=200, snr_q4=8, status="responded"),
         ]
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = reporter._build_snapshot(entries, {"a"})
+            serialized = await reporter._build_snapshot(entries, {"a"})
         snapshot = json.loads(serialized)
         assert snapshot["neighbors"][0]["heard_secs_ago"] == 0
 
-    def test_pubkey_lexical_tie_break(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_pubkey_lexical_tie_break(self, monkeypatch):
         """Spec 25.4-36: pubkey tie-break is deterministic."""
         reporter = CommunityNeighborReporter()
         reporter._modules["a"] = _Module("a", {})
@@ -609,20 +616,15 @@ class TestJsonContractComprehensive:
             ScopeQueryEntry("AA" * 32, heard_timestamp=95, snr_q4=8, status="timeout"),
         ]
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = reporter._build_snapshot(entries, {"a"})
+            serialized = await reporter._build_snapshot(entries, {"a"})
         keys = [n["pubkey"] for n in json.loads(serialized)["neighbors"]]
         assert keys == ["AA" * 32, "BB" * 32, "CC" * 32]
 
-    def test_json_escaping_handles_quotes_in_scopes(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_json_escaping_handles_quotes_in_scopes(self, monkeypatch):
         """Spec 25.4-37: unusual scope chars are JSON-safe."""
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module(
-            "a",
-            {
-                "neighbor_self_scopes": "a",
-                "neighbor_origin": "B",
-            },
-        )
+        reporter._modules["a"] = _Module("a", {})
         entries = [
             ScopeQueryEntry(
                 "AA" * 32, heard_timestamp=90, snr_q4=8, scopes='foo"bar', status="responded"
@@ -630,19 +632,14 @@ class TestJsonContractComprehensive:
         ]
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = reporter._build_snapshot(entries, {"a"})
+            serialized = await reporter._build_snapshot(entries, {"a"})
         snapshot = json.loads(serialized)
         assert snapshot["neighbors"][0]["scopes"] == 'foo"bar'
 
-    def test_scopes_with_backslash_survive_roundtrip(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_scopes_with_backslash_survive_roundtrip(self, monkeypatch):
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module(
-            "a",
-            {
-                "neighbor_self_scopes": "a",
-                "neighbor_origin": "B",
-            },
-        )
+        reporter._modules["a"] = _Module("a", {})
         entries = [
             ScopeQueryEntry(
                 "AA" * 32, heard_timestamp=90, snr_q4=8, scopes="path\\trail", status="responded"
@@ -650,20 +647,15 @@ class TestJsonContractComprehensive:
         ]
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = reporter._build_snapshot(entries, {"a"})
+            serialized = await reporter._build_snapshot(entries, {"a"})
         snapshot = json.loads(serialized)
         assert snapshot["neighbors"][0]["scopes"] == "path\\trail"
 
-    def test_progressive_truncation_leaves_valid_json(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_progressive_truncation_leaves_valid_json(self, monkeypatch):
         """Spec 25.4-38: tail removed, valid JSON remains."""
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module(
-            "a",
-            {
-                "neighbor_origin": "O",
-                "neighbor_self_scopes": "S",
-            },
-        )
+        reporter._modules["a"] = _Module("a", {})
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
 
         entries = [
@@ -671,7 +663,7 @@ class TestJsonContractComprehensive:
             for i in range(200)
         ]
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = reporter._build_snapshot(entries, {"a"})
+            serialized = await reporter._build_snapshot(entries, {"a"})
 
         assert serialized is not None
         snapshot = json.loads(serialized)
@@ -679,19 +671,14 @@ class TestJsonContractComprehensive:
         encoded = serialized.encode("utf-8")
         assert 0 < len(encoded) < MAX_SNAPSHOT_BYTES
 
-    def test_root_object_too_large_fails_cleanly(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_root_object_too_large_fails_cleanly(self, monkeypatch):
         """Spec 25.4-39: root too large -> None."""
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module(
-            "a",
-            {
-                "neighbor_origin": "N",
-                "neighbor_self_scopes": "x",
-            },
-        )
+        reporter._modules["a"] = _Module("a", {})
         monkeypatch.setattr("app.fanout.community_neighbors.MAX_SNAPSHOT_BYTES", 20)
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = reporter._build_snapshot([], {"a"})
+            serialized = await reporter._build_snapshot([], {"a"})
         assert serialized is None
 
     def test_origin_quote_stripping(self):
@@ -704,7 +691,8 @@ class TestJsonContractComprehensive:
         assert normalize_neighbor_origin(None) == ""
         assert normalize_neighbor_origin("") == ""
 
-    def test_snr_is_float_not_string(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_snr_is_float_not_string(self, monkeypatch):
         """SNR is a JSON number, not string."""
         reporter = CommunityNeighborReporter()
         reporter._modules["a"] = _Module("a", {})
@@ -713,13 +701,14 @@ class TestJsonContractComprehensive:
             ScopeQueryEntry("AA" * 32, heard_timestamp=90, snr_q4=10, status="responded"),
         ]
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = reporter._build_snapshot(entries, {"a"})
+            serialized = await reporter._build_snapshot(entries, {"a"})
         snapshot = json.loads(serialized)
         snr = snapshot["neighbors"][0]["snr"]
         assert isinstance(snr, (int, float))
         assert snr == 2.5
 
-    def test_heard_secs_ago_is_int(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_heard_secs_ago_is_int(self, monkeypatch):
         reporter = CommunityNeighborReporter()
         reporter._modules["a"] = _Module("a", {})
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
@@ -727,11 +716,12 @@ class TestJsonContractComprehensive:
             ScopeQueryEntry("AA" * 32, heard_timestamp=90, snr_q4=4, status="timeout"),
         ]
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = reporter._build_snapshot(entries, {"a"})
+            serialized = await reporter._build_snapshot(entries, {"a"})
         snapshot = json.loads(serialized)
         assert isinstance(snapshot["neighbors"][0]["heard_secs_ago"], int)
 
-    def test_status_is_valid_enum(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_status_is_valid_enum(self, monkeypatch):
         reporter = CommunityNeighborReporter()
         reporter._modules["a"] = _Module("a", {})
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
@@ -740,7 +730,7 @@ class TestJsonContractComprehensive:
                 ScopeQueryEntry("AA" * 32, heard_timestamp=90, snr_q4=4, status=status),
             ]
             with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-                serialized = reporter._build_snapshot(entries, {"a"})
+                serialized = await reporter._build_snapshot(entries, {"a"})
             assert status in serialized
 
 
@@ -1263,23 +1253,18 @@ class TestScopeQueryEarlyCompletion:
 
 
 class TestJsonKeyFormat:
-    def test_origin_id_and_pubkey_are_uppercase_64_char_hex(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_origin_id_and_pubkey_are_uppercase_64_char_hex(self, monkeypatch):
         """Spec 25.4-31: origin_id and pubkey must be uppercase 64-character hex."""
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module(
-            "a",
-            {
-                "neighbor_origin": "Test",
-                "neighbor_self_scopes": "EU",
-            },
-        )
+        reporter._modules["a"] = _Module("a", {})
         entries = [
             ScopeQueryEntry("aa" * 32, heard_timestamp=90, snr_q4=8, scopes="", status="responded"),
         ]
         monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
 
         with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
-            serialized = reporter._build_snapshot(entries, {"a"})
+            serialized = await reporter._build_snapshot(entries, {"a"})
 
         assert serialized is not None
         snapshot = json.loads(serialized)

--- a/tests/test_community_neighbors_comprehensive.py
+++ b/tests/test_community_neighbors_comprehensive.py
@@ -1,0 +1,1415 @@
+"""Comprehensive spec-compliance tests for MQTT neighbor reporting.
+
+Covers the canonical specification test matrix (S25 and S35) that was
+not already covered by the existing focused contract tests.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+from contextlib import asynccontextmanager
+from hashlib import sha256
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from Crypto.Cipher import AES
+from meshcore import EventType
+
+from app.decoder import PayloadType, derive_public_key, derive_shared_secret
+from app.fanout.community_neighbors import (
+    MAX_SNAPSHOT_BYTES,
+    CommunityNeighborReporter,
+    NeighborCacheEntry,
+    NeighborReporterError,
+    ScopeQueryEntry,
+    _bounded_scope_text,
+    _quantize_snr,
+    normalize_neighbor_origin,
+    normalize_self_scopes,
+)
+
+OUR_PRIVATE_KEY = bytes.fromhex(
+    "58BA1940E97099CBB4357C62CE9C7F4B245C94C90D722E67201B989F9FEACF7B"
+    "77ACADDB84438514022BDB0FC3140C2501859BE1772AC7B8C7E41DC0F40490A1"
+)
+PEER_PUBLIC_KEY = bytes.fromhex("A1B2C3D3BA9F5FA8705B9845FE11CC6F01D1D49CAAF4D122AC7121663C5BEEC7")
+OUR_PUBLIC_KEY = derive_public_key(OUR_PRIVATE_KEY)
+
+
+class _Module:
+    def __init__(self, config_id, config, *, connected=True):
+        self.config_id = config_id
+        self.config = config
+        self.neighbor_publisher_connected = connected
+        self.published = []
+
+    async def publish_neighbor_snapshot(self, serialized_snapshot):
+        self.published.append(serialized_snapshot)
+        return True
+
+
+class _FailingModule:
+    def __init__(self, config_id, config, *, connected=True):
+        self.config_id = config_id
+        self.config = config
+        self.neighbor_publisher_connected = connected
+        self.published = []
+
+    async def publish_neighbor_snapshot(self, serialized_snapshot):
+        return False
+
+
+def _response_packet(*, tag, scopes):
+    plaintext = tag + (1_700_000_000).to_bytes(4, "little") + scopes
+    plaintext += bytes((-len(plaintext)) % 16)
+    secret = derive_shared_secret(OUR_PRIVATE_KEY, PEER_PUBLIC_KEY)
+    ciphertext = AES.new(secret[:16], AES.MODE_ECB).encrypt(plaintext)
+    mac = hmac.new(secret, ciphertext, sha256).digest()[:2]
+    p = bytes((OUR_PUBLIC_KEY[0], PEER_PUBLIC_KEY[0])) + mac + ciphertext
+    return bytes(((int(PayloadType.RESPONSE) << 2) | 0x02, 0)) + p
+
+
+def _make_envelope(
+    *, payload_type=None, hop_count=0, transport_codes=None, route_type=0x02, payload=b""
+):
+    return SimpleNamespace(
+        payload_type=payload_type,
+        hop_count=hop_count,
+        transport_codes=transport_codes,
+        route_type=route_type,
+        payload=payload,
+    )
+
+
+# ===================================================================
+# S25.1 / S25.2  Cache & discovery tests
+# ===================================================================
+
+
+class TestCacheExtended:
+    @pytest.mark.asyncio
+    async def test_non_repeater_advert_is_not_cached(self):
+        """Spec 25.1-2: role != 2 must not create a cache entry."""
+        reporter = CommunityNeighborReporter()
+        envelope = _make_envelope(payload_type=int(PayloadType.ADVERT))
+        for role in (1, 3, 4):
+            advert = SimpleNamespace(public_key="11" * 32, timestamp=1, device_role=role)
+            with (
+                patch(
+                    "app.fanout.community_neighbors.parse_packet_envelope", return_value=envelope
+                ),
+                patch("app.fanout.community_neighbors.parse_advertisement", return_value=advert),
+                patch("app.fanout.community_neighbors.verify_advert_signature", return_value=True),
+                patch("app.keystore.get_public_key", return_value=None),
+            ):
+                await reporter.observe_packet(b"raw")
+        assert reporter._cache == {}
+
+    @pytest.mark.asyncio
+    async def test_relayed_advert_is_not_cached(self):
+        """Spec 25.1-3: hop_count > 0 must not create a cache entry."""
+        reporter = CommunityNeighborReporter()
+        envelope = _make_envelope(payload_type=int(PayloadType.ADVERT), hop_count=2)
+        advert = SimpleNamespace(public_key="11" * 32, timestamp=1, device_role=2)
+        with (
+            patch("app.fanout.community_neighbors.parse_packet_envelope", return_value=envelope),
+            patch("app.fanout.community_neighbors.parse_advertisement", return_value=advert),
+            patch("app.fanout.community_neighbors.verify_advert_signature", return_value=True),
+            patch("app.keystore.get_public_key", return_value=None),
+        ):
+            await reporter.observe_packet(b"raw")
+        assert reporter._cache == {}
+
+    @pytest.mark.asyncio
+    async def test_existing_identity_is_updated_in_place(self):
+        """Spec 25.1-5: same public key updates one slot only."""
+        reporter = CommunityNeighborReporter()
+        key = "ab" * 32
+        await reporter.put_neighbor(key, advert_timestamp=1, measured_snr=1.0, heard_timestamp=10)
+        await reporter.put_neighbor(key, advert_timestamp=2, measured_snr=3.0, heard_timestamp=20)
+        assert len(reporter._cache) == 1
+        cached = reporter._cache[key]
+        assert cached.advert_timestamp == 2
+        assert cached.heard_timestamp == 20
+        assert cached.snr_q4 == 12
+
+    @pytest.mark.asyncio
+    async def test_empty_slot_is_used_before_eviction(self):
+        """Spec 25.1-6: empty slot (heard_timestamp==0) chosen first."""
+        reporter = CommunityNeighborReporter(cache_limit=2)
+        reporter._cache["01" * 32] = NeighborCacheEntry(
+            public_key="01" * 32, advert_timestamp=1, heard_timestamp=10, snr_q4=4
+        )
+        reporter._cache["02" * 32] = NeighborCacheEntry(
+            public_key="02" * 32, advert_timestamp=2, heard_timestamp=0, snr_q4=0
+        )
+        await reporter.put_neighbor(
+            "03" * 32, advert_timestamp=3, measured_snr=1, heard_timestamp=30
+        )
+        assert "01" * 32 in reporter._cache
+        assert "03" * 32 in reporter._cache
+        assert "02" * 32 not in reporter._cache
+
+    def test_snr_quantization_covers_negative_and_fractions(self):
+        """Spec 25.1-8: quarter-dB quantization for all sign/value combos."""
+        assert _quantize_snr(2.62) == 10
+        assert _quantize_snr(-0.75) == -3
+        assert _quantize_snr(0.0) == 0
+        assert _quantize_snr(-3.25) == -13
+        assert _quantize_snr(8.5) == 34
+
+    def test_snr_clamps_at_int8_bounds(self):
+        assert _quantize_snr(50.0) == 127
+        assert _quantize_snr(-50.0) == -128
+
+    @pytest.mark.asyncio
+    async def test_cache_survives_refresh_cycle(self):
+        """Spec 25.1-9: stale cache entry remains after refresh completes."""
+        reporter = CommunityNeighborReporter()
+        await reporter.put_neighbor(
+            "01" * 32, advert_timestamp=1, measured_snr=1, heard_timestamp=10
+        )
+        reporter._discovery_tag = 42
+        reporter._discovery_deadline = 0
+        reporter._discovery_periodic = False
+        reporter._discovery_manual_scope = False
+        reporter._discovery_target_ids = set()
+        await reporter._tick()
+        assert "01" * 32 in reporter._cache
+
+    @pytest.mark.asyncio
+    async def test_remove_neighbor_explicitly_prunes_entry(self):
+        """Spec 6.4: explicit removal resets slot."""
+        reporter = CommunityNeighborReporter()
+        await reporter.put_neighbor(
+            "01" * 32, advert_timestamp=1, measured_snr=1, heard_timestamp=10
+        )
+        await reporter.put_neighbor(
+            "02" * 32, advert_timestamp=2, measured_snr=2, heard_timestamp=20
+        )
+        removed = await reporter.remove_neighbor("01" * 32)
+        assert removed is True
+        assert "01" * 32 not in reporter._cache
+        assert "02" * 32 in reporter._cache
+
+    @pytest.mark.asyncio
+    async def test_remove_nonexistent_neighbor_returns_false(self):
+        reporter = CommunityNeighborReporter()
+        removed = await reporter.remove_neighbor("FF" * 32)
+        assert removed is False
+
+    @pytest.mark.asyncio
+    async def test_clear_neighbors_removes_all(self):
+        reporter = CommunityNeighborReporter()
+        await reporter.put_neighbor(
+            "01" * 32, advert_timestamp=1, measured_snr=1, heard_timestamp=10
+        )
+        await reporter.put_neighbor(
+            "02" * 32, advert_timestamp=2, measured_snr=2, heard_timestamp=20
+        )
+        count = await reporter.clear_neighbors()
+        assert count == 2
+        assert reporter._cache == {}
+
+    @pytest.mark.asyncio
+    async def test_unsigned_advert_is_not_cached(self):
+        """Advert that fails signature verification must not enter cache."""
+        reporter = CommunityNeighborReporter()
+        envelope = _make_envelope(payload_type=int(PayloadType.ADVERT))
+        advert = SimpleNamespace(public_key="11" * 32, timestamp=1, device_role=2)
+        with (
+            patch("app.fanout.community_neighbors.parse_packet_envelope", return_value=envelope),
+            patch("app.fanout.community_neighbors.parse_advertisement", return_value=advert),
+            patch("app.fanout.community_neighbors.verify_advert_signature", return_value=False),
+            patch("app.keystore.get_public_key", return_value=None),
+        ):
+            await reporter.observe_packet(b"raw")
+        assert reporter._cache == {}
+
+    def test_observation_id_dedup_eviction_at_256(self):
+        """Spec 35-62: observation-ID set prunes beyond 256 entries."""
+        reporter = CommunityNeighborReporter()
+        for i in range(300):
+            reporter._remember_observation_id(i)
+        assert len(reporter._seen_observation_ids) <= 256
+        assert 0 not in reporter._seen_observation_ids
+
+
+class TestDiscoveryResponseValidation:
+    @pytest.mark.asyncio
+    async def test_wrong_response_tag_is_ignored(self):
+        """Spec 25.2-11: mismatched discovery response tag ignored."""
+        reporter = CommunityNeighborReporter()
+        reporter._discovery_tag = 0xABCD1234
+        reporter._discovery_deadline = 999999.0
+        payload = {
+            "node_type": 2,
+            "path_len": 0,
+            "tag": bytes.fromhex("00000001").hex(),
+            "pubkey": PEER_PUBLIC_KEY.hex(),
+            "SNR": 5.0,
+        }
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            await reporter._observe_discovery_response(payload)
+        assert PEER_PUBLIC_KEY.hex().lower() not in reporter._cache
+
+    @pytest.mark.asyncio
+    async def test_expired_discovery_response_is_ignored(self):
+        """Spec 25.2-12: response after 60s window ignored."""
+        reporter = CommunityNeighborReporter()
+        reporter._discovery_tag = 42
+        reporter._discovery_deadline = 0
+        payload = {
+            "node_type": 2,
+            "path_len": 0,
+            "tag": (42).to_bytes(4, "little").hex(),
+            "pubkey": PEER_PUBLIC_KEY.hex(),
+            "SNR": 5.0,
+        }
+        await reporter._observe_discovery_response(payload)
+        assert PEER_PUBLIC_KEY.hex().lower() not in reporter._cache
+
+    @pytest.mark.asyncio
+    async def test_wrong_node_type_in_discovery_response_is_ignored(self):
+        """Spec 25.2-13: non-repeater discovery response ignored."""
+        reporter = CommunityNeighborReporter()
+        reporter._discovery_tag = 42
+        reporter._discovery_deadline = 999999.0
+        payload = {
+            "node_type": 1,
+            "path_len": 0,
+            "tag": (42).to_bytes(4, "little").hex(),
+            "pubkey": PEER_PUBLIC_KEY.hex(),
+            "SNR": 5.0,
+        }
+        await reporter._observe_discovery_response(payload)
+        assert PEER_PUBLIC_KEY.hex().lower() not in reporter._cache
+
+    @pytest.mark.asyncio
+    async def test_short_public_key_in_discovery_response_is_ignored(self):
+        """Spec 25.2-14: short pubkey ignored."""
+        reporter = CommunityNeighborReporter()
+        reporter._discovery_tag = 42
+        reporter._discovery_deadline = 999999.0
+        for bad_key in ("AA", "AA" * 16, ""):
+            payload = {
+                "node_type": 2,
+                "path_len": 0,
+                "tag": (42).to_bytes(4, "little").hex(),
+                "pubkey": bad_key,
+                "SNR": 5.0,
+            }
+            await reporter._observe_discovery_response(payload)
+        assert not reporter._cache
+
+    @pytest.mark.asyncio
+    async def test_self_identity_in_discovery_response_is_ignored(self):
+        """Spec 25.2-15: self-identity ignored."""
+        reporter = CommunityNeighborReporter()
+        reporter._discovery_tag = 42
+        reporter._discovery_deadline = 999999.0
+        payload = {
+            "node_type": 2,
+            "path_len": 0,
+            "tag": (42).to_bytes(4, "little").hex(),
+            "pubkey": OUR_PUBLIC_KEY.hex(),
+            "SNR": 5.0,
+        }
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            await reporter._observe_discovery_response(payload)
+        assert OUR_PUBLIC_KEY.hex().lower() not in reporter._cache
+
+    @pytest.mark.asyncio
+    async def test_discovery_response_uses_observer_side_snr(self):
+        """Spec 25.2-16: observer-side SNR stored, not response byte 1."""
+        reporter = CommunityNeighborReporter()
+        reporter._discovery_tag = 42
+        reporter._discovery_deadline = 999999.0
+        payload = {
+            "node_type": 2,
+            "path_len": 0,
+            "tag": (42).to_bytes(4, "little").hex(),
+            "pubkey": PEER_PUBLIC_KEY.hex(),
+            "SNR": 6.5,
+        }
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            await reporter._observe_discovery_response(payload)
+        cached = reporter._cache.get(PEER_PUBLIC_KEY.hex().lower())
+        assert cached is not None
+        assert cached.snr_q4 == _quantize_snr(6.5)
+
+    @pytest.mark.asyncio
+    async def test_discovery_response_non_zero_path_ignored(self):
+        """Discovery response with non-zero-hop path_len ignored."""
+        reporter = CommunityNeighborReporter()
+        reporter._discovery_tag = 42
+        reporter._discovery_deadline = 999999.0
+        payload = {
+            "node_type": 2,
+            "path_len": 2,
+            "tag": (42).to_bytes(4, "little").hex(),
+            "pubkey": PEER_PUBLIC_KEY.hex(),
+            "SNR": 5.0,
+        }
+        await reporter._observe_discovery_response(payload)
+        assert PEER_PUBLIC_KEY.hex().lower() not in reporter._cache
+
+    @pytest.mark.asyncio
+    async def test_none_discovery_tag_ignored(self):
+        """No active discovery tag -> response ignored."""
+        reporter = CommunityNeighborReporter()
+        reporter._discovery_tag = None
+        payload = {
+            "node_type": 2,
+            "path_len": 0,
+            "tag": "aabbccdd",
+            "pubkey": PEER_PUBLIC_KEY.hex(),
+            "SNR": 5.0,
+        }
+        await reporter._observe_discovery_response(payload)
+        assert not reporter._cache
+
+
+# ===================================================================
+# S25.3  Scope-query phase tests
+# ===================================================================
+
+
+class TestScopeQueryPhase:
+    @pytest.mark.asyncio
+    async def test_each_cached_neighbor_receives_one_request(self):
+        """Spec 25.3-18: one request per cached neighbor."""
+        reporter = CommunityNeighborReporter()
+        key_a = "aa" * 32
+        key_b = "bb" * 32
+        reporter._modules["x"] = _Module("x", {}, connected=True)
+        await reporter.put_neighbor(key_a, advert_timestamp=1, measured_snr=1, heard_timestamp=10)
+        await reporter.put_neighbor(key_b, advert_timestamp=2, measured_snr=2, heard_timestamp=20)
+
+        seen_keys = set()
+        tag_ctr = [0]
+
+        async def fake_send(mc, pk):
+            seen_keys.add(pk)
+            tag_ctr[0] += 1
+            tag_hex = format(tag_ctr[0], "08x")
+            return SimpleNamespace(
+                type=0x0F,
+                payload={"expected_ack": bytes.fromhex(tag_hex)},
+            )
+
+        @asynccontextmanager
+        async def fake_radio_op(name, **kwargs):
+            class _Mc:
+                pass
+
+            yield _Mc()
+
+        with (
+            patch.object(reporter, "_send_regions_request", fake_send),
+            patch("app.services.radio_runtime.radio_runtime.radio_operation", fake_radio_op),
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+        ):
+            await reporter._begin_scope_queries(target_ids={"x"}, periodic=False, manual=True)
+
+        assert seen_keys == {key_a, key_b}
+
+    @pytest.mark.asyncio
+    async def test_send_allocation_failure_becomes_send_failed(self):
+        """Spec 25.3-19: send failure -> send_failed status."""
+        reporter = CommunityNeighborReporter()
+        key = "CC" * 32
+        reporter._modules["x"] = _Module("x", {})
+        await reporter.put_neighbor(key, advert_timestamp=1, measured_snr=1, heard_timestamp=10)
+
+        async def failing_send(mc, pk):
+            return None
+
+        @asynccontextmanager
+        async def fake_radio_op(name, **kwargs):
+            class _Mc:
+                pass
+
+            yield _Mc()
+
+        with (
+            patch.object(reporter, "_send_regions_request", failing_send),
+            patch("app.services.radio_runtime.radio_runtime.radio_operation", fake_radio_op),
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+        ):
+            await reporter._begin_scope_queries(target_ids={"x"}, periodic=False, manual=True)
+
+        assert len(reporter._modules["x"].published) == 1
+        snapshot = json.loads(reporter._modules["x"].published[0])
+        assert snapshot["neighbors"][0]["status"] == "send_failed"
+        assert snapshot["neighbors"][0]["scopes"] == ""
+
+    @pytest.mark.asyncio
+    async def test_valid_empty_response_completes_with_empty_scopes(self):
+        """Spec 25.3-20: 8-byte response -> responded with empty scopes."""
+        reporter = CommunityNeighborReporter()
+        tag = bytes.fromhex("A1B2C3D4")
+        entry = ScopeQueryEntry(
+            public_key=PEER_PUBLIC_KEY.hex(),
+            heard_timestamp=100,
+            snr_q4=8,
+            request_tag=tag.hex().lower(),
+        )
+        reporter._scope_active = True
+        reporter._scope_entries = [entry]
+        reporter._queries_by_tag[entry.request_tag] = entry
+
+        with (
+            patch("app.keystore.get_private_key", return_value=OUR_PRIVATE_KEY),
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+        ):
+            await reporter.observe_packet(_response_packet(tag=tag, scopes=b""))
+
+        assert entry.status == "responded"
+        assert entry.scopes == ""
+
+    @pytest.mark.asyncio
+    async def test_too_short_response_does_not_complete_entry(self):
+        """Spec 25.3-22: < 8 bytes plaintext -> entry stays pending."""
+        reporter = CommunityNeighborReporter()
+        entry = ScopeQueryEntry(
+            public_key=PEER_PUBLIC_KEY.hex(),
+            heard_timestamp=100,
+            snr_q4=8,
+            request_tag="01020304",
+        )
+        accepted = await reporter._accept_scope_response(entry, b"abc")
+        assert accepted is False
+        assert entry.status == "pending"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_response_does_not_overwrite_completed(self):
+        """Spec 25.3-24: duplicate response leaves completed entry alone."""
+        reporter = CommunityNeighborReporter()
+        entry = ScopeQueryEntry(
+            public_key=PEER_PUBLIC_KEY.hex(),
+            heard_timestamp=100,
+            snr_q4=8,
+            request_tag="01020304",
+            scopes="original",
+            status="responded",
+        )
+        reporter._scope_active = True
+        dup_plaintext = bytes.fromhex("01020304") + b"\x00" * 4 + b"overwrite"
+        accepted = await reporter._accept_scope_response(entry, dup_plaintext)
+        assert accepted is False
+        assert entry.scopes == "original"
+        assert entry.status == "responded"
+
+    @pytest.mark.asyncio
+    async def test_batch_timeout_marks_pending_as_timeout(self):
+        """Spec 25.3-28: remaining pending -> timeout."""
+        reporter = CommunityNeighborReporter()
+        key_a = "EE" * 32
+        key_b = "FF" * 32
+        reporter._modules["x"] = _Module("x", {})
+        reporter._scope_active = True
+        reporter._scope_entries = [
+            ScopeQueryEntry(key_a, heard_timestamp=10, snr_q4=4, status="responded"),
+            ScopeQueryEntry(key_b, heard_timestamp=20, snr_q4=4, status="pending"),
+        ]
+        reporter._scope_target_ids = {"x"}
+
+        captured_entries = reporter._scope_entries
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            await reporter._finish_scope_queries(timeout=True)
+
+        assert captured_entries[1].status == "timeout"
+
+    @pytest.mark.asyncio
+    async def test_zero_neighbor_cache_publishes_immediately(self):
+        """Spec 25.3-29: empty cache -> immediate snapshot with []."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["x"] = _Module("x", {})
+        assert reporter._cache == {}
+
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            await reporter._begin_scope_queries(target_ids={"x"}, periodic=False, manual=True)
+
+        assert len(reporter._modules["x"].published) == 1
+        snapshot = json.loads(reporter._modules["x"].published[0])
+        assert snapshot["neighbors"] == []
+
+    @pytest.mark.asyncio
+    async def test_bounded_scope_text_nulls_and_caps(self):
+        """Verify 95-byte cap and null termination."""
+        ninety_bytes = b"a" * 90 + b"\x00trailing"
+        result = _bounded_scope_text(ninety_bytes)
+        assert len(result) <= 95
+        assert "trailing" not in result
+
+
+# ===================================================================
+# S25.4  JSON contract tests
+# ===================================================================
+
+
+class TestJsonContractComprehensive:
+    def test_required_fields_present(self, monkeypatch):
+        """Spec 25.4-30: all required fields present in root + neighbor."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_origin": "Test",
+                "neighbor_self_scopes": "EU,US",
+            },
+        )
+        entries = [
+            ScopeQueryEntry(
+                "AA" * 32, heard_timestamp=90, snr_q4=8, scopes="EU", status="responded"
+            ),
+        ]
+        monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
+
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            serialized = reporter._build_snapshot(entries, {"a"})
+
+        assert serialized is not None
+        snapshot = json.loads(serialized)
+        assert "timestamp" in snapshot
+        assert "origin" in snapshot
+        assert "origin_id" in snapshot
+        assert "self" in snapshot
+        assert "scopes" in snapshot["self"]
+        assert "status" not in snapshot["self"]
+        assert "neighbors" in snapshot
+        neighbor = snapshot["neighbors"][0]
+        for field in ("pubkey", "snr", "heard_secs_ago", "scopes", "status"):
+            assert field in neighbor, f"missing {field}"
+
+    def test_clock_backward_clamp(self, monkeypatch):
+        """Spec 25.4-33: future heard_timestamp -> age 0."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module("a", {})
+        monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
+        entries = [
+            ScopeQueryEntry("AA" * 32, heard_timestamp=200, snr_q4=8, status="responded"),
+        ]
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            serialized = reporter._build_snapshot(entries, {"a"})
+        snapshot = json.loads(serialized)
+        assert snapshot["neighbors"][0]["heard_secs_ago"] == 0
+
+    def test_pubkey_lexical_tie_break(self, monkeypatch):
+        """Spec 25.4-36: pubkey tie-break is deterministic."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module("a", {})
+        monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
+        entries = [
+            ScopeQueryEntry("CC" * 32, heard_timestamp=95, snr_q4=8, status="timeout"),
+            ScopeQueryEntry("BB" * 32, heard_timestamp=95, snr_q4=8, status="timeout"),
+            ScopeQueryEntry("AA" * 32, heard_timestamp=95, snr_q4=8, status="timeout"),
+        ]
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            serialized = reporter._build_snapshot(entries, {"a"})
+        keys = [n["pubkey"] for n in json.loads(serialized)["neighbors"]]
+        assert keys == ["AA" * 32, "BB" * 32, "CC" * 32]
+
+    def test_json_escaping_handles_quotes_in_scopes(self, monkeypatch):
+        """Spec 25.4-37: unusual scope chars are JSON-safe."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_self_scopes": "a",
+                "neighbor_origin": "B",
+            },
+        )
+        entries = [
+            ScopeQueryEntry(
+                "AA" * 32, heard_timestamp=90, snr_q4=8, scopes='foo"bar', status="responded"
+            ),
+        ]
+        monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            serialized = reporter._build_snapshot(entries, {"a"})
+        snapshot = json.loads(serialized)
+        assert snapshot["neighbors"][0]["scopes"] == 'foo"bar'
+
+    def test_scopes_with_backslash_survive_roundtrip(self, monkeypatch):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_self_scopes": "a",
+                "neighbor_origin": "B",
+            },
+        )
+        entries = [
+            ScopeQueryEntry(
+                "AA" * 32, heard_timestamp=90, snr_q4=8, scopes="path\\trail", status="responded"
+            ),
+        ]
+        monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            serialized = reporter._build_snapshot(entries, {"a"})
+        snapshot = json.loads(serialized)
+        assert snapshot["neighbors"][0]["scopes"] == "path\\trail"
+
+    def test_progressive_truncation_leaves_valid_json(self, monkeypatch):
+        """Spec 25.4-38: tail removed, valid JSON remains."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_origin": "O",
+                "neighbor_self_scopes": "S",
+            },
+        )
+        monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
+
+        entries = [
+            ScopeQueryEntry(format(i, "064d"), heard_timestamp=i, snr_q4=4, status="timeout")
+            for i in range(200)
+        ]
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            serialized = reporter._build_snapshot(entries, {"a"})
+
+        assert serialized is not None
+        snapshot = json.loads(serialized)
+        assert len(snapshot["neighbors"]) < 200
+        encoded = serialized.encode("utf-8")
+        assert 0 < len(encoded) < MAX_SNAPSHOT_BYTES
+
+    def test_root_object_too_large_fails_cleanly(self, monkeypatch):
+        """Spec 25.4-39: root too large -> None."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_origin": "N",
+                "neighbor_self_scopes": "x",
+            },
+        )
+        monkeypatch.setattr("app.fanout.community_neighbors.MAX_SNAPSHOT_BYTES", 20)
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            serialized = reporter._build_snapshot([], {"a"})
+        assert serialized is None
+
+    def test_origin_quote_stripping(self):
+        """Neighbor origin strips surrounding quotes."""
+        assert normalize_neighbor_origin("'Observer'") == "Observer"
+        assert normalize_neighbor_origin('"Device 1"') == "Device 1"
+        assert normalize_neighbor_origin("NoQuotes") == "NoQuotes"
+
+    def test_empty_origin_normalization(self):
+        assert normalize_neighbor_origin(None) == ""
+        assert normalize_neighbor_origin("") == ""
+
+    def test_snr_is_float_not_string(self, monkeypatch):
+        """SNR is a JSON number, not string."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module("a", {})
+        monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
+        entries = [
+            ScopeQueryEntry("AA" * 32, heard_timestamp=90, snr_q4=10, status="responded"),
+        ]
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            serialized = reporter._build_snapshot(entries, {"a"})
+        snapshot = json.loads(serialized)
+        snr = snapshot["neighbors"][0]["snr"]
+        assert isinstance(snr, (int, float))
+        assert snr == 2.5
+
+    def test_heard_secs_ago_is_int(self, monkeypatch):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module("a", {})
+        monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
+        entries = [
+            ScopeQueryEntry("AA" * 32, heard_timestamp=90, snr_q4=4, status="timeout"),
+        ]
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            serialized = reporter._build_snapshot(entries, {"a"})
+        snapshot = json.loads(serialized)
+        assert isinstance(snapshot["neighbors"][0]["heard_secs_ago"], int)
+
+    def test_status_is_valid_enum(self, monkeypatch):
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module("a", {})
+        monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
+        for status in ("responded", "timeout", "send_failed"):
+            entries = [
+                ScopeQueryEntry("AA" * 32, heard_timestamp=90, snr_q4=4, status=status),
+            ]
+            with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+                serialized = reporter._build_snapshot(entries, {"a"})
+            assert status in serialized
+
+
+# ===================================================================
+# S25.5  MQTT delivery tests
+# ===================================================================
+
+
+class TestMqttDelivery:
+    @pytest.mark.asyncio
+    async def test_multi_slot_partial_success_tracks_ok(self):
+        """Spec 25.5-43: one successful slot -> ok."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["good"] = _Module("good", {})
+        reporter._modules["bad"] = _FailingModule("bad", {})
+
+        entries = [ScopeQueryEntry("AA" * 32, heard_timestamp=10, snr_q4=4, status="responded")]
+        reporter._scope_active = True
+        reporter._scope_entries = entries
+        reporter._scope_target_ids = {"good", "bad"}
+
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            await reporter._finish_scope_queries(timeout=False)
+
+        assert reporter._last_publish_result == "ok"
+        assert len(reporter._modules["good"].published) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_connected_slots_yields_failed(self):
+        """Spec 25.5-44: no connected slots -> failed."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["off"] = _Module("off", {}, connected=False)
+
+        entries = [ScopeQueryEntry("AA" * 32, heard_timestamp=10, snr_q4=4, status="responded")]
+        reporter._scope_active = True
+        reporter._scope_entries = entries
+        reporter._scope_target_ids = {"off"}
+
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            await reporter._finish_scope_queries(timeout=False)
+
+        assert reporter._last_publish_result == "failed"
+
+    @pytest.mark.asyncio
+    async def test_all_failing_slots_yields_failed(self):
+        """Spec 25.5-44: all publish calls fail -> failed."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["bad1"] = _FailingModule("bad1", {})
+        reporter._modules["bad2"] = _FailingModule("bad2", {})
+
+        entries = [ScopeQueryEntry("AA" * 32, heard_timestamp=10, snr_q4=4, status="responded")]
+        reporter._scope_active = True
+        reporter._scope_entries = entries
+        reporter._scope_target_ids = {"bad1", "bad2"}
+
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            await reporter._finish_scope_queries(timeout=False)
+
+        assert reporter._last_publish_result == "failed"
+
+    @pytest.mark.asyncio
+    async def test_pending_handoff_protection(self):
+        """Spec 25.5-46: publishing flag blocks new scope start."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["one"] = _Module("one", {}, connected=True)
+        reporter._publishing_snapshot = True
+
+        result = await reporter.start_manual_snapshot("one")
+        assert result["status"] == "active"
+        assert "still publishing" in result["message"]
+
+
+# ===================================================================
+# S25.6  Scheduling tests
+# ===================================================================
+
+
+class TestScheduling:
+    @pytest.mark.asyncio
+    async def test_periodic_schedule_becomes_due_on_enable(self):
+        """Spec 25.6-50: first periodic run due immediately."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_reporting_enabled": True,
+                "neighbor_reporting_interval_hours": 24,
+            },
+        )
+        await reporter._ensure_periodic_schedule()
+        assert reporter._next_periodic_at is not None
+        assert reporter._next_periodic_at <= 99999999999.0
+
+    @pytest.mark.asyncio
+    async def test_shorter_interval_module_brings_forward_schedule(self):
+        """Spec 35-57: shorter-interval module joins, schedule recalculated."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["slow"] = _Module(
+            "slow",
+            {
+                "neighbor_reporting_enabled": True,
+                "neighbor_reporting_interval_hours": 336,
+            },
+        )
+        await reporter._ensure_periodic_schedule()
+        original_at = reporter._next_periodic_at
+
+        reporter._modules["fast"] = _Module(
+            "fast",
+            {
+                "neighbor_reporting_enabled": True,
+                "neighbor_reporting_interval_hours": 12,
+            },
+        )
+        await reporter._ensure_periodic_schedule()
+
+        if original_at is not None:
+            assert reporter._next_periodic_at is not None
+            assert reporter._next_periodic_at <= original_at
+
+    @pytest.mark.asyncio
+    async def test_schedule_cleared_when_no_periodic_modules(self):
+        """Spec 25.6-53: schedule cleared with no periodic reporters."""
+        reporter = CommunityNeighborReporter()
+        reporter._next_periodic_at = 12345.0
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_reporting_enabled": False,
+            },
+        )
+        await reporter._ensure_periodic_schedule()
+        assert reporter._next_periodic_at is None
+
+    def test_periodic_interval_range_enforced(self):
+        """Spec 25.6-49: interval clamped 12-336 hours."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_reporting_enabled": True,
+                "neighbor_reporting_interval_hours": 6,
+            },
+        )
+        seconds = reporter._periodic_interval_seconds()
+        assert seconds >= 12 * 3600
+
+        reporter._modules["a"].config["neighbor_reporting_interval_hours"] = 500
+        seconds = reporter._periodic_interval_seconds()
+        assert seconds <= 336 * 3600
+
+    def test_periodic_interval_is_minimum_across_modules(self):
+        """Spec 35-57: effective interval is min of all enabled."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_reporting_enabled": True,
+                "neighbor_reporting_interval_hours": 48,
+            },
+        )
+        reporter._modules["b"] = _Module(
+            "b",
+            {
+                "neighbor_reporting_enabled": True,
+                "neighbor_reporting_interval_hours": 24,
+            },
+        )
+        reporter._modules["c"] = _Module(
+            "c",
+            {
+                "neighbor_reporting_enabled": False,
+                "neighbor_reporting_interval_hours": 12,
+            },
+        )
+        seconds = reporter._periodic_interval_seconds()
+        assert seconds == 24 * 3600
+
+    @pytest.mark.asyncio
+    async def test_manual_discovery_join_when_active(self):
+        """Spec 25.6-51: manual discover joins existing window."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module("a", {})
+        reporter._discovery_tag = 42
+        reporter._discovery_deadline = 999999.0
+        result = await reporter.start_manual_discovery("a")
+        assert result["status"] == "joined"
+
+    @pytest.mark.asyncio
+    async def test_manual_snapshot_queues_behind_active_refresh(self):
+        """Spec 25.6-52: manual scope request queues behind refresh."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module("a", {}, connected=True)
+        reporter._discovery_tag = 42
+        reporter._discovery_deadline = 999999.0
+        result = await reporter.start_manual_snapshot("a")
+        assert result["status"] == "queued"
+
+
+# ===================================================================
+# S35  Shared coordinator tests
+# ===================================================================
+
+
+class TestSharedCoordinator:
+    @pytest.mark.asyncio
+    async def test_two_slots_both_get_snapshot(self):
+        """Spec 35-56: both periodic and manual slots get snapshot."""
+        reporter = CommunityNeighborReporter()
+        mod_a = _Module("a", {"neighbor_reporting_enabled": True})
+        mod_b = _Module("b", {"neighbor_reporting_enabled": True})
+        reporter._modules["a"] = mod_a
+        reporter._modules["b"] = mod_b
+        await reporter.put_neighbor(
+            "AA" * 32, advert_timestamp=1, measured_snr=1, heard_timestamp=10
+        )
+
+        tag_ctr = [0]
+
+        async def fake_send(mc, pk):
+            tag_ctr[0] += 1
+            return SimpleNamespace(
+                type=0x0F, payload={"expected_ack": bytes.fromhex(format(tag_ctr[0], "08x"))}
+            )
+
+        @asynccontextmanager
+        async def fake_radio_op(name, **kwargs):
+            class _Mc:
+                pass
+
+            yield _Mc()
+
+        with (
+            patch.object(reporter, "_send_regions_request", fake_send),
+            patch("app.services.radio_runtime.radio_runtime.radio_operation", fake_radio_op),
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+        ):
+            await reporter._begin_scope_queries(target_ids={"a", "b"}, periodic=True, manual=False)
+
+        assert len(mod_a.published) == 1
+        assert len(mod_b.published) == 1
+        assert mod_a.published[0] == mod_b.published[0]
+
+    @pytest.mark.asyncio
+    async def test_disabled_slot_not_receiving_snapshot(self):
+        """Spec 35-58: disabled slot doesn't receive snapshot."""
+        reporter = CommunityNeighborReporter()
+        mod_on = _Module("on", {"neighbor_reporting_enabled": True})
+        mod_off = _Module("off", {"neighbor_reporting_enabled": False})
+        reporter._modules["on"] = mod_on
+        reporter._modules["off"] = mod_off
+        await reporter.put_neighbor(
+            "AA" * 32, advert_timestamp=1, measured_snr=1, heard_timestamp=10
+        )
+
+        tag_ctr = [0]
+
+        async def fake_send(mc, pk):
+            tag_ctr[0] += 1
+            return SimpleNamespace(
+                type=0x0F, payload={"expected_ack": bytes.fromhex(format(tag_ctr[0], "08x"))}
+            )
+
+        @asynccontextmanager
+        async def fake_radio_op(name, **kwargs):
+            class _Mc:
+                pass
+
+            yield _Mc()
+
+        with (
+            patch.object(reporter, "_send_regions_request", fake_send),
+            patch("app.services.radio_runtime.radio_runtime.radio_operation", fake_radio_op),
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+        ):
+            await reporter._begin_scope_queries(
+                target_ids={"on", "off"}, periodic=True, manual=False
+            )
+
+        assert len(mod_on.published) >= 1
+        assert len(mod_off.published) == 0
+
+    @pytest.mark.asyncio
+    async def test_slot_removal_during_active_phase_does_not_crash(self):
+        """Spec 35-59: slot removal during active phase doesn't crash."""
+        reporter = CommunityNeighborReporter()
+        mod_a = _Module("a", {}, connected=True)
+        reporter._modules["a"] = mod_a
+        reporter._scope_active = True
+        reporter._scope_entries = [
+            ScopeQueryEntry("AA" * 32, heard_timestamp=10, snr_q4=4, status="responded")
+        ]
+        reporter._scope_target_ids = {"a", "b"}
+        await reporter.unregister_module("b")
+        assert "b" not in reporter._modules
+        assert reporter._scope_active is True
+
+    @pytest.mark.asyncio
+    async def test_status_reports_correct_phases(self):
+        """Spec 18: status endpoint reports all phases correctly."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module("a", {"neighbor_reporting_enabled": True})
+
+        status = reporter.status_for("a")
+        assert status["phase"] in ("idle", "due", "scheduled")
+        assert "cache_size" in status
+        assert "periodic_enabled" in status
+        assert "last_publish_result" in status
+
+        reporter._publishing_snapshot = True
+        assert reporter.status_for("a")["phase"] == "publishing"
+
+        reporter._publishing_snapshot = False
+        reporter._scope_active = True
+        assert reporter.status_for("a")["phase"] == "scopes"
+
+        reporter._scope_active = False
+        reporter._discovery_tag = 42
+        assert reporter.status_for("a")["phase"] == "refresh"
+
+    @pytest.mark.asyncio
+    async def test_scope_queries_blocked_when_bridge_not_connected(self):
+        """Spec 22.2: manual scope request rejected when bridge not connected."""
+        reporter = CommunityNeighborReporter()
+        module = _Module("a", {}, connected=False)
+        reporter._modules["a"] = module
+        with pytest.raises(NeighborReporterError, match="not running"):
+            await reporter.start_manual_snapshot("a")
+
+    @pytest.mark.asyncio
+    async def test_begin_scope_checks_connected_broker_exists(self):
+        """Scope queries only start when at least one broker is connected."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["off"] = _Module("off", {}, connected=False)
+        await reporter.put_neighbor(
+            "AA" * 32, advert_timestamp=1, measured_snr=1, heard_timestamp=10
+        )
+
+        with pytest.raises(NeighborReporterError, match="not running"):
+            await reporter._begin_scope_queries(target_ids={"off"}, periodic=False, manual=True)
+
+
+# ===================================================================
+# S25.1 / S25.5  Edge-case tests
+# ===================================================================
+
+
+class TestEdgeCases:
+    @pytest.mark.asyncio
+    async def test_put_neighbor_rejects_invalid_hex(self):
+        reporter = CommunityNeighborReporter()
+        await reporter.put_neighbor("ZZ" * 32, advert_timestamp=1, measured_snr=1)
+        assert reporter._cache == {}
+
+    @pytest.mark.asyncio
+    async def test_put_neighbor_rejects_wrong_length_key(self):
+        reporter = CommunityNeighborReporter()
+        await reporter.put_neighbor("AA" * 16, advert_timestamp=1, measured_snr=1)
+        assert reporter._cache == {}
+
+    @pytest.mark.asyncio
+    async def test_put_neighbor_rejects_self_key(self):
+        reporter = CommunityNeighborReporter()
+        with patch.object(reporter, "_local_public_key_hex", return_value="01" * 32):
+            await reporter.put_neighbor("01" * 32, advert_timestamp=1, measured_snr=1)
+        assert reporter._cache == {}
+
+    def test_normalize_self_scopes_rejects_control_chars(self):
+        with pytest.raises(ValueError):
+            normalize_self_scopes(["good", "bad\x01"])
+
+    def test_normalize_self_scopes_strips_hash_and_trims(self):
+        assert normalize_self_scopes(" #*, #Sweden , ##double") == "*,Sweden,#double"
+
+
+# ===================================================================
+# S25.2  Discovery request payload bytes (Spec 25.2-10)
+# ===================================================================
+
+
+class TestDiscoveryRequestBytes:
+    @pytest.mark.asyncio
+    async def test_discovery_request_repeater_only_full_key_no_modified_since(self):
+        """Spec 5.2.1 + 25.2-10: exact request args for zero-hop discovery.
+
+        The spec requires:
+          - Control type 0x80 (discovery request, prefix_only=False)
+          - Filter bitmask 0x04 (1 << ADV_TYPE_REPEATER)
+          - Unique uint32 tag, little-endian
+          - Modified-since timestamp = 0
+
+        We verify that send_node_discover_req is called with these args.
+        """
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module("a", {}, connected=True)
+
+        captured_filter_bits = []
+        captured_prefix_only = []
+        captured_tag = []
+        captured_since = []
+
+        async def recording_discover_req(filter_bits, prefix_only=False, tag=None, since=None):
+            captured_filter_bits.append(filter_bits)
+            captured_prefix_only.append(prefix_only)
+            captured_tag.append(tag)
+            captured_since.append(since)
+            return SimpleNamespace(type=0x0F)
+
+        @asynccontextmanager
+        async def fake_radio_op(name, **kwargs):
+            class _Mc:
+                pass
+
+            mc = _Mc()
+            mc.commands = SimpleNamespace()
+            mc.commands.send_node_discover_req = AsyncMock(side_effect=recording_discover_req)
+            mc.subscribe = MagicMock()
+            mc.subscribe.return_value = SimpleNamespace(unsubscribe=MagicMock())
+            yield mc
+
+        with (
+            patch("app.services.radio_runtime.radio_runtime.radio_operation", fake_radio_op),
+        ):
+            await reporter._begin_discovery(periodic=False, target_ids={"a"})
+
+        assert captured_filter_bits == [4]
+        assert captured_prefix_only == [False]
+        assert captured_since == [0]
+        assert isinstance(captured_tag[0], int)
+        assert captured_tag[0] != 0
+
+
+# ===================================================================
+# S25.3  Scope overlay non-interference + early completion
+# ===================================================================
+
+
+class TestScopeOverlayAcLNonInterference:
+    @pytest.mark.asyncio
+    async def test_wrong_tag_from_acl_neighbor_does_not_complete_overlay(self):
+        """Spec 25.3-26: unrelated ACL response does not intercept overlay.
+
+        A response that shares the compact source hash of a queried
+        neighbor but carries a different tag must not complete the
+        overlay entry.  This keeps normal ACL traffic flowing while
+        the overlay only matches pending scope-query answers.
+        """
+        reporter = CommunityNeighborReporter()
+        entry = ScopeQueryEntry(
+            public_key=PEER_PUBLIC_KEY.hex(),
+            heard_timestamp=100,
+            snr_q4=8,
+            request_tag="01020304",
+        )
+        reporter._scope_active = True
+        reporter._scope_entries = [entry]
+        reporter._queries_by_tag[entry.request_tag] = entry
+
+        # Build a response with a non-matching tag
+        unmatched_tag = bytes.fromhex("DEADBEEF")
+        with (
+            patch("app.keystore.get_private_key", return_value=OUR_PRIVATE_KEY),
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+        ):
+            await reporter.observe_packet(
+                _response_packet(tag=unmatched_tag, scopes=b"should_not_appear")
+            )
+
+        assert entry.status == "pending"
+        assert entry.scopes == ""
+
+
+class TestScopeQueryEarlyCompletion:
+    @pytest.mark.asyncio
+    async def test_early_completion_when_all_entries_finish_before_timeout(self):
+        """Spec 25.3-27: snapshot publishes before 30s when all entries complete.
+
+        When every scope-query entry leaves pending state before the
+        shared 30-second deadline, _finish_scope_queries must be called
+        immediately rather than waiting for the deadline.
+        """
+        reporter = CommunityNeighborReporter()
+        reporter._modules["x"] = _Module("x", {})
+        key_a = "aa" * 32
+        key_b = "bb" * 32
+        await reporter.put_neighbor(key_a, advert_timestamp=1, measured_snr=1, heard_timestamp=10)
+        await reporter.put_neighbor(key_b, advert_timestamp=2, measured_snr=2, heard_timestamp=20)
+
+        tag_ctr = [0]
+
+        async def instant_fail_send(mc, pk):
+            tag_ctr[0] += 1
+            return None
+
+        @asynccontextmanager
+        async def fake_radio_op(name, **kwargs):
+            class _Mc:
+                pass
+
+            yield _Mc()
+
+        with (
+            patch.object(reporter, "_send_regions_request", instant_fail_send),
+            patch(
+                "app.services.radio_runtime.radio_runtime.radio_operation",
+                fake_radio_op,
+            ),
+            patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
+        ):
+            await reporter._begin_scope_queries(target_ids={"x"}, periodic=False, manual=True)
+
+        assert len(reporter._modules["x"].published) == 1
+        assert reporter._scope_active is False
+        assert reporter._scope_deadline is None
+
+
+# ===================================================================
+# S25.4  Uppercase public keys (Spec 25.4-31)
+# ===================================================================
+
+
+class TestJsonKeyFormat:
+    def test_origin_id_and_pubkey_are_uppercase_64_char_hex(self, monkeypatch):
+        """Spec 25.4-31: origin_id and pubkey must be uppercase 64-character hex."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_origin": "Test",
+                "neighbor_self_scopes": "EU",
+            },
+        )
+        entries = [
+            ScopeQueryEntry("aa" * 32, heard_timestamp=90, snr_q4=8, scopes="", status="responded"),
+        ]
+        monkeypatch.setattr("app.fanout.community_neighbors._wall_time", lambda: 100)
+
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            serialized = reporter._build_snapshot(entries, {"a"})
+
+        assert serialized is not None
+        snapshot = json.loads(serialized)
+
+        assert snapshot["origin_id"] == OUR_PUBLIC_KEY.hex().upper()
+        assert all(c in "0123456789ABCDEF" for c in snapshot["origin_id"])
+
+        for neighbor in snapshot["neighbors"]:
+            assert neighbor["pubkey"] == neighbor["pubkey"].upper()
+            assert all(c in "0123456789ABCDEF" for c in neighbor["pubkey"])
+
+
+# ===================================================================
+# S25.5  Invalid IATA does not block other slots (Spec 25.5-45)
+# ===================================================================
+
+
+class TestInvalidIataSlotRobustness:
+    @pytest.mark.asyncio
+    async def test_invalid_iata_skipped_other_slot_gets_snapshot(self):
+        """Spec 25.5-45: one invalid IATA does not block valid alternative slots.
+
+        When one module's publish_neighbor_snapshot returns False (e.g.
+        because its IATA code is invalid), the reporter continues to the
+        next module rather than aborting.
+        """
+        reporter = CommunityNeighborReporter()
+        mod_good = _Module("good", {"iata": "STO"}, connected=True)
+        mod_bad = _Module("bad_iata", {"iata": "xx"}, connected=True)
+        reporter._modules["good"] = mod_good
+        reporter._modules["bad_iata"] = mod_bad
+        reporter._scope_active = True
+        reporter._scope_entries = [
+            ScopeQueryEntry("AA" * 32, heard_timestamp=10, snr_q4=4, status="responded")
+        ]
+        reporter._scope_target_ids = {"good", "bad_iata"}
+
+        with patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY):
+            await reporter._finish_scope_queries(timeout=False)
+
+        assert reporter._last_publish_result == "ok"
+        assert len(mod_good.published) == 1
+
+
+# ===================================================================
+# S25.6  No retry loop on failure + timer wraparound
+# ===================================================================
+
+
+class TestFailedCycleRescheduling:
+    @pytest.mark.asyncio
+    async def test_failed_cycle_schedules_next_interval_not_tight_loop(self):
+        """Spec 25.6-54: failed phase schedules next interval, no retry loop.
+
+        When _begin_discovery fails (e.g. radio error), a periodic
+        reporter must schedule the next interval rather than creating
+        a tight retry loop.
+        """
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_reporting_enabled": True,
+                "neighbor_reporting_interval_hours": 24,
+            },
+            connected=True,
+        )
+        reporter._next_periodic_at = 0
+
+        async def failing_discover_req(filter_bits, prefix_only=False, tag=None, since=None):
+            return SimpleNamespace(type=EventType.ERROR)
+
+        @asynccontextmanager
+        async def fake_radio_op(name, **kwargs):
+            class _Mc:
+                pass
+
+            mc = _Mc()
+            mc.commands = MagicMock()
+            mc.commands.send_node_discover_req = AsyncMock(side_effect=failing_discover_req)
+            mc.subscribe = MagicMock()
+            mc.subscribe.return_value = SimpleNamespace(unsubscribe=MagicMock())
+            yield mc
+
+        with (
+            patch(
+                "app.services.radio_runtime.radio_runtime.radio_operation",
+                fake_radio_op,
+            ),
+        ):
+            try:
+                await reporter._begin_discovery(periodic=True, target_ids={"a"})
+            except NeighborReporterError:
+                pass
+
+        assert reporter._discovery_tag is None
+        assert reporter._next_periodic_at is not None
+        assert reporter._next_periodic_at > 0
+
+
+class TestTimerWraparound:
+    def test_deadline_signed_delta_works_across_wraparound(self):
+        """Spec 25.6-55: signed delta handles 32-bit monotonic wrap.
+
+        Using a signed difference for deadline checks ensures correct
+        behavior when monotonic wraps.
+        """
+
+        # Simulate a "now" after wrap and a deadline set before wrap.
+        # The signed delta (now - deadline) should be positive when expired.
+        wrap_now = 2**31 - 4
+        deadline_before = 2**31 - 10
+
+        # This is conceptually what the spec requires: expired = signed32(now - deadline) >= 0
+        delta = wrap_now - deadline_before
+        assert delta >= 0
+
+        # Not yet expired: now < deadline (both on same side of wrap)
+        assert (deadline_before - 10 - deadline_before) < 0
+
+    def test_periodic_interval_stays_below_max_safe_signed_range(self):
+        """Spec 11.4: interval must stay below safe signed-difference window."""
+        reporter = CommunityNeighborReporter()
+        reporter._modules["a"] = _Module(
+            "a",
+            {
+                "neighbor_reporting_enabled": True,
+                "neighbor_reporting_interval_hours": 336,
+            },
+        )
+        seconds = reporter._periodic_interval_seconds()
+        assert seconds <= 336 * 3600
+        assert seconds < 2**31

--- a/tests/test_community_neighbors_comprehensive.py
+++ b/tests/test_community_neighbors_comprehensive.py
@@ -452,18 +452,14 @@ class TestScopeQueryPhase:
             patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
             pytest.raises(NeighborReporterError, match="requires the radio private key"),
         ):
-            await reporter._begin_scope_queries(
-                target_ids={"x"}, periodic=False, manual=True
-            )
+            await reporter._begin_scope_queries(target_ids={"x"}, periodic=False, manual=True)
 
         assert reporter._scope_active is False
 
     @pytest.mark.asyncio
     async def test_periodic_scope_query_defers_when_private_key_is_missing(self):
         reporter = CommunityNeighborReporter()
-        reporter._modules["x"] = _Module(
-            "x", {"neighbor_reporting_enabled": True}, connected=True
-        )
+        reporter._modules["x"] = _Module("x", {"neighbor_reporting_enabled": True}, connected=True)
         await reporter.put_neighbor(
             "aa" * 32, advert_timestamp=1, measured_snr=1, heard_timestamp=10
         )
@@ -472,9 +468,7 @@ class TestScopeQueryPhase:
             patch("app.keystore.get_private_key", return_value=None),
             patch("app.keystore.get_public_key", return_value=OUR_PUBLIC_KEY),
         ):
-            await reporter._begin_scope_queries(
-                target_ids={"x"}, periodic=True, manual=False
-            )
+            await reporter._begin_scope_queries(target_ids={"x"}, periodic=True, manual=False)
 
         assert reporter._scope_active is False
         assert reporter._last_publish_result == "failed"
@@ -1030,9 +1024,7 @@ class TestScheduling:
     @pytest.mark.asyncio
     async def test_disabling_periodic_does_not_cancel_manual_owner(self):
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module(
-            "a", {"neighbor_reporting_enabled": False}
-        )
+        reporter._modules["a"] = _Module("a", {"neighbor_reporting_enabled": False})
         reporter._discovery_tag = 42
         reporter._discovery_deadline = 999999999.0
         reporter._discovery_periodic = True
@@ -1047,9 +1039,7 @@ class TestScheduling:
     @pytest.mark.asyncio
     async def test_disabling_periodic_keeps_manual_scope_ownership(self):
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module(
-            "a", {"neighbor_reporting_enabled": False}
-        )
+        reporter._modules["a"] = _Module("a", {"neighbor_reporting_enabled": False})
         reporter._discovery_tag = 42
         reporter._discovery_deadline = 999999999.0
         reporter._discovery_periodic = True
@@ -1064,9 +1054,7 @@ class TestScheduling:
     @pytest.mark.asyncio
     async def test_disabling_periodic_cancels_pure_periodic_refresh(self):
         reporter = CommunityNeighborReporter()
-        reporter._modules["a"] = _Module(
-            "a", {"neighbor_reporting_enabled": False}
-        )
+        reporter._modules["a"] = _Module("a", {"neighbor_reporting_enabled": False})
         reporter._discovery_tag = 42
         reporter._discovery_deadline = 999999999.0
         reporter._discovery_periodic = True
@@ -1241,9 +1229,7 @@ class TestSharedCoordinator:
         reporter._publishing_snapshot = True
         monkeypatch.setattr("app.fanout.community_neighbors._monotonic", lambda: 122.0)
 
-        await reporter._begin_scope_queries(
-            target_ids={"on"}, periodic=True, manual=False
-        )
+        await reporter._begin_scope_queries(target_ids={"on"}, periodic=True, manual=False)
 
         assert reporter._scope_active is False
         assert reporter._next_periodic_at == 122.0
@@ -1256,9 +1242,7 @@ class TestSharedCoordinator:
         )
         monkeypatch.setattr("app.fanout.community_neighbors._monotonic", lambda: 123.0)
 
-        await reporter._begin_scope_queries(
-            target_ids={"off"}, periodic=True, manual=False
-        )
+        await reporter._begin_scope_queries(target_ids={"off"}, periodic=True, manual=False)
 
         assert reporter._scope_active is False
         assert reporter._next_periodic_at == 123.0

--- a/tests/test_fanout_hitlist.py
+++ b/tests/test_fanout_hitlist.py
@@ -890,6 +890,14 @@ class TestCommunityMqttIataValidation:
         # Should not raise
         _validate_mqtt_community_config({"iata": "PDX"})
 
+    def test_non_string_iata_rejected_as_validation_error(self):
+        from app.routers.fanout import _validate_mqtt_community_config
+
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_mqtt_community_config({"iata": 123})
+        assert exc_info.value.status_code == 400
+        assert "string" in exc_info.value.detail
+
     def test_invalid_iata_format_rejected(self):
         from app.routers.fanout import _validate_mqtt_community_config
 


### PR DESCRIPTION
This feature was fully written by **GPT 5.6 Terra** with small help from Deepseek v4 Pro.

The neighbor reporting feature is based on the implementation present at [observer.gessaman.com](https://observer.gessaman.com) and was ported from there.

---

## What this adds

A shared MQTT community neighbor-reporting system that discovers directly reachable repeater neighbors via zero-hop radio, queries each for its flood-allowed scopes via authenticated anonymous requests, and publishes canonical JSON snapshots to every configured Community MQTT broker slot at QoS 1.

### Backend

- **CommunityNeighborReporter** (`app/fanout/community_neighbors.py`): shared coordinator with a bounded 50-entry repeater cache, 60-second zero-hop discovery window, 30-second per-neighbor scope-query batch, canonical JSON snapshot construction (10,240-byte buffer with sorted-prefix truncation), and MQTT QoS-1 handoff across all Community MQTT slots.
- Passive zero-hop repeater adverts and active discovery responses populate the same LRU cache. Non-repeater, relayed, and Share adverts are rejected.
- Scope queries use authenticated anonymous requests (firmware `CMD_SEND_ANON_REQ`) with per-neighbor tag matching via a temporary decryption overlay that does not disturb the normal ACL contact table.
- Snapshot JSON follows the canonical schema: `timestamp`, `origin`, `origin_id`, `self.scopes`, and `neighbors[]` with `pubkey`, `snr`, `heard_secs_ago`, `scopes`, `status`.
- Origin is always the radio name (falls back to "MeshCore Device"). Self scopes are derived from `app_settings.flood_scope` (wildcard `*` when unset).
- Scheduling: periodic reporting disabled by default, 24-hour interval default, 12–336 hour range, manual discovery/snapshot commands, join-existing-refresh, and phase-appropriate cancellation.
- API endpoints: `GET /api/fanout/{id}/community-neighbors/status`, `POST …/discover`, `POST …/snapshot`, `DELETE …/{public_key}`, `DELETE …` (clear all).
- Wire passive observation into `packet_processor.py` and `mqtt_community.py`.
- Fix 2 pyright type errors in `_quantize_snr` and `normalize_self_scopes`.
- Add thread-safety annotation in `mqtt_base.py`.

### Frontend

- Community MQTT neighbor reporting config UI in Settings > Fanout: toggle, interval (12–336h), topic template with `{IATA}`/`{PUBLIC_KEY}`/`{TYPE}` placeholders, retain checkbox.
- API client: `communityNeighborStatus`, `discoverCommunityNeighbors`, `publishCommunityNeighborSnapshot`.
- TypeScript types for neighbor config fields.

### Tests

- **92 test functions** across two files covering cache behavior, discovery response validation, scope query phase, JSON contract compliance, MQTT delivery semantics, periodic scheduling, shared coordinator behavior, and edge cases.